### PR TITLE
Firetext keyword handling, fixes.

### DIFF
--- a/src/AAA.php
+++ b/src/AAA.php
@@ -1,6 +1,8 @@
 <?php
 namespace Alphagov\GovWifi;
 
+use PDO;
+
 class AAA {
     public $user;
     public $mac;

--- a/src/Config.php
+++ b/src/Config.php
@@ -3,6 +3,7 @@ namespace Alphagov\GovWifi;
 
 class Config {
     const HEALTH_CHECK_USER = "HEALTH";
+    const FIRETEXT_EMPTY_KEYWORD = "NON-SPECIFIED";
     private static $instance;
     public $values;
 

--- a/src/sms/index.php
+++ b/src/sms/index.php
@@ -5,7 +5,9 @@ require "../common.php";
 
 $smsReq = new SmsRequest();
 
-// FireText uses source and message (and keyword for short numbers)
+// FireText uses source, message, and keyword
+// for short numbers keyword is set to the keyword entered,
+// otherwise it's a string constant.
 if (isset($_REQUEST['source'])) {
     $smsReq->setSender($_REQUEST['source']);
 } else {
@@ -14,10 +16,11 @@ if (isset($_REQUEST['source'])) {
 
 if (isset($_REQUEST["message"])) {
     $keyword = "";
-    if (!empty($_REQUEST["keyword"])) {
+    if (!empty($_REQUEST["keyword"]) &&
+        Config::FIRETEXT_EMPTY_KEYWORD != strtoupper($_REQUEST["keyword"])) {
         $keyword = $_REQUEST["keyword"];
     }
-    $smsReq->setMessage($keyword . " " . $_REQUEST["message"]);
+    $smsReq->setMessage(trim($keyword . " " . $_REQUEST["message"]));
 } else {
     $smsReq->setMessage($_REQUEST["content"]);
 }

--- a/src/sms/index.php
+++ b/src/sms/index.php
@@ -5,16 +5,22 @@ require "../common.php";
 
 $smsReq = new SmsRequest();
 
-if (isset($_REQUEST['source']))
+// FireText uses source and message (and keyword for short numbers)
+if (isset($_REQUEST['source'])) {
     $smsReq->setSender($_REQUEST['source']);
-else
-    $smsReq->setSender($_REQUEST["sender"]);
+} else {
+    $smsReq->setSender($_REQUEST['sender']);
+}
 
-if (isset($_REQUEST["message"]))
-    $smsReq->setMessage($_REQUEST["message"]);
-else
+if (isset($_REQUEST["message"])) {
+    $keyword = "";
+    if (!empty($_REQUEST["keyword"])) {
+        $keyword = $_REQUEST["keyword"];
+    }
+    $smsReq->setMessage($keyword . " " . $_REQUEST["message"]);
+} else {
     $smsReq->setMessage($_REQUEST["content"]);
-
+}
 
 if ($smsReq->sender->validMobile)
 {
@@ -24,19 +30,15 @@ if ($smsReq->sender->validMobile)
         case "security":
             $smsReq->security();
             break;
-
         case "new":
             $smsReq->newPassword();
             break;
-
         case "help":
             $smsReq->help();
             break;
-
-	case "agree":
+        case "agree":
             $smsReq->signUp();
             break;
-
         default:
             if (preg_match('/^[0-9]{4}$/', $firstword)) {
                 $smsReq->dailyCode();
@@ -46,11 +48,7 @@ if ($smsReq->sender->validMobile)
                 $smsReq->other();
             }
             break;
-
     }
-
-
-} else
-{
+} else {
     error_log("SMS: Invalid number " . $smsReq->sender->text);
 }

--- a/src/sns/index.php
+++ b/src/sns/index.php
@@ -69,7 +69,7 @@ if (isset($data['SubscribeURL'])) {
         case "enroll":
         case "enrol":
         case "signup":
-            $emailreq->enroll();
+            $emailreq->signUp();
         break;
         case "verify":
             $emailreq->verify();
@@ -78,10 +78,10 @@ if (isset($data['SubscribeURL'])) {
             $emailreq->sponsor();
         break;
         case "newsite":
-            $emailreq->newsite();
+            $emailreq->newSite();
         break;
         case "logrequest":
-            $emailreq->logrequest();
+            $emailreq->logRequest();
         break;
     }
 }


### PR DESCRIPTION
- Fix PDO include,
- Fix function name
- Prepend the firetext keyword to the message (if provided) so we can handle the keyword "agree" on short numbers. "Go" is stripped later in the process, so no change is necessary there.