### PR TITLE
Extend logging for cases when we do receive an email but a command is not found.

### DIFF
--- a/src/sns/index.php
+++ b/src/sns/index.php
@@ -43,6 +43,7 @@ if (isset($data['SubscribeURL'])) {
         $pattern,
         reset($message['mail']['commonHeaders']['to']),
         $toMatches);
+    error_log("AWS SNS EMAIL: To : " . $toMatches[0]);
     $emailreq->setEmailTo($toMatches[0]);
     $emailreq->setEmailSubject($message['mail']['commonHeaders']['subject']);
     $bucket = $message['receipt']['action']['bucketName'];
@@ -83,6 +84,9 @@ if (isset($data['SubscribeURL'])) {
         break;
         case "logrequest":
             $emailreq->logRequest();
+        break;
+        default:
+            error_log("AWS SNS EMAIL: No command found. Have we been cc'd?");
         break;
     }
 }


### PR DESCRIPTION
This could indicate an issue with the email setup (there is an email address that is not handled by the system) - however most likely someone just cc'd us in by mistake.