### PR TITLE
Allow any return-path - check email "from" only

### DIFF
--- a/src/sns/index.php
+++ b/src/sns/index.php
@@ -32,17 +32,14 @@ if (isset($data['SubscribeURL'])) {
 } else {
     error_log("EMAIL original message metadata: " . $data['Message']);
     $message = json_decode($data['Message'], true);
-    $emailFrom = $message['mail']['commonHeaders']['returnPath'];
     $emailPattern = "/([a-zA-Z0-9_\.\-]+@[a-zA-Z0-9_\.\-]+)/";
+
+    preg_match(
+        $emailPattern,
+        reset($message['mail']['commonHeaders']['from']),
+        $fromMatches);
+    $emailFrom = $fromMatches[0];
     // TODO: extend validation, fail fast, log.
-    $emailFromId = new Identifier($emailFrom);
-    if (! $emailFromId->validEmail) {
-        preg_match(
-            $emailPattern,
-            reset($message['mail']['commonHeaders']['from']),
-            $fromMatches);
-        $emailFrom = $fromMatches[0];
-    }
     $emailreq->setEmailFrom($emailFrom);
 
     preg_match(


### PR DESCRIPTION
As shown by a test with a @greenfinch.com email address, region-internal SES emails override the return-path parameter, as such it is not reliable for domain/admin validation.