### PR TITLE
Admin email journey updates 20170411

### DIFF
--- a/src/EmailRequest.php
+++ b/src/EmailRequest.php
@@ -328,7 +328,7 @@ class EmailRequest extends GovWifiBase {
         $email = new EmailResponse;
         $email->to = $orgAdmin->email;
         if (!$site->id && count($newSiteIPs) == 0 && count($newSiteSourceIPs) == 0) {
-            $email->newSiteBlank($site);
+            $email->newSiteBlank($this->emailSubject);
             $email->send($orgAdmin->emailManagerAddress);
             return;
         }

--- a/src/EmailRequest.php
+++ b/src/EmailRequest.php
@@ -355,29 +355,29 @@ class EmailRequest extends GovWifiBase {
                 $site->addSourceIPs($newSiteSourceIPs);
             }
 
-            // Create the site information pdf
-            $pdf = new PDF();
-            $pdf->populateNewSite($site);
-            $report = new Report;
-            $report->orgAdmin = $orgAdmin;
-            $report->getIPList($site);
-            $pdf->generatePDF($report);
 
             // Create email response and attach the pdf
             $email = new EmailResponse;
             $email->to = $orgAdmin->email;
             if ($outcome) {
                 $email->newSite($action, $outcome, $site);
+                // Create the site information pdf
+                $pdf = new PDF();
+                $pdf->populateNewSite($site);
+                $report = new Report;
+                $report->orgAdmin = $orgAdmin;
+                $report->getIPList($site);
+                $pdf->generatePDF($report);
+                $email->fileName = $pdf->filename;
+                $email->filePath = $pdf->filepath;
+                // Create sms response for the code
+                $sms = new SmsResponse($orgAdmin->mobile);
+                $sms->sendNewsitePassword($pdf);
             } else {
                 $email->newSiteBlank($site);
             }
-            $email->fileName = $pdf->filename;
-            $email->filePath = $pdf->filepath;
             $email->send($orgAdmin->emailManagerAddress);
 
-            // Create sms response for the code
-            $sms = new SmsResponse($orgAdmin->mobile);
-            $sms->sendNewsitePassword($pdf);
         } else {
             error_log(
                 "EMAIL: Ignoring new site request from : "

--- a/src/EmailRequest.php
+++ b/src/EmailRequest.php
@@ -308,81 +308,80 @@ class EmailRequest extends GovWifiBase {
     public function newSite() {
         $this->emailSubject = str_ireplace("re: ", "", $this->emailSubject);
         $orgAdmin = new OrgAdmin($this->emailFrom->text);
-        if ($orgAdmin->authorised) {
-            error_log(
-                "EMAIL: processing new site request from : "
-                . $this->emailFrom->text);
-
-            // Add the new site & IP addresses
-            $outcome = "Existing site updated\n";
-            $site = new Site();
-            $site->loadByAddress($this->emailSubject);
-            $action = "updated";
-
-            if (!$site->id) {
-                $site->org_id = $orgAdmin->orgId;
-                $site->org_name = $orgAdmin->orgName;
-                $site->name = $this->emailSubject;
-                error_log(
-                    "EMAIL: creating new site : " . $site->name);
-                $outcome = "New site created\n";
-                $site->setRadKey();
-                if ($site->updateFromEmail($this->emailBody))
-                    $outcome .= "Site attributes updated\n";
-                $site->writeRecord();
-                $action = "created";
-            } else if ($site->updateFromEmail($this->emailBody)) {
-                error_log(
-                    "EMAIL: updating site attributes : " . $site->name);
-                $outcome .= "Site attributes updated\n";
-                $site->writeRecord();
-            }
-
-            $newSiteIPs = $this->ipList();
-            if (count($newSiteIPs) > 0) {
-                error_log(
-                    "EMAIL: Adding client IP addresses : " . $site->name);
-                $outcome .= count($newSiteIPs) . " RADIUS IP Addresses added\n";
-                $site->addIPs($newSiteIPs);
-            }
-
-            $newSiteSourceIPs = $this->sourceIpList();
-            if (count($newSiteSourceIPs) > 0) {
-                error_log(
-                    "EMAIL: Adding source IP addresses : " . $site->name);
-                $outcome .=
-                    count($newSiteIPs) . " Source IP Address ranges added\n";
-                $site->addSourceIPs($newSiteSourceIPs);
-            }
-
-
-            // Create email response and attach the pdf
-            $email = new EmailResponse;
-            $email->to = $orgAdmin->email;
-            if ($outcome) {
-                $email->newSite($action, $outcome, $site);
-                // Create the site information pdf
-                $pdf = new PDF();
-                $pdf->populateNewSite($site);
-                $report = new Report;
-                $report->orgAdmin = $orgAdmin;
-                $report->getIPList($site);
-                $pdf->generatePDF($report);
-                $email->fileName = $pdf->filename;
-                $email->filePath = $pdf->filepath;
-                // Create sms response for the code
-                $sms = new SmsResponse($orgAdmin->mobile);
-                $sms->sendNewsitePassword($pdf);
-            } else {
-                $email->newSiteBlank($site);
-            }
-            $email->send($orgAdmin->emailManagerAddress);
-
-        } else {
+        if (!$orgAdmin->authorised) {
             error_log(
                 "EMAIL: Ignoring new site request from : "
                 . $this->emailFrom->text);
+            return;
         }
+        error_log(
+            "EMAIL: processing new site request from : "
+            . $this->emailFrom->text);
+
+        // Add the new site & IP addresses
+        $outcome = "Existing site updated\n";
+        $site = new Site();
+        $site->loadByAddress($this->emailSubject);
+        $action = "updated";
+        $newSiteIPs = $this->ipList();
+        $newSiteSourceIPs = $this->sourceIpList();
+        $email = new EmailResponse;
+        $email->to = $orgAdmin->email;
+        if (!$site->id && count($newSiteIPs) == 0 && count($newSiteSourceIPs) == 0) {
+            $email->newSiteBlank($site);
+            $email->send($orgAdmin->emailManagerAddress);
+            return;
+        }
+
+        if (!$site->id) {
+            $site->org_id = $orgAdmin->orgId;
+            $site->org_name = $orgAdmin->orgName;
+            $site->name = $this->emailSubject;
+            error_log(
+                "EMAIL: creating new site : " . $site->name);
+            $outcome = "New site created\n";
+            $site->setRadKey();
+            if ($site->updateFromEmail($this->emailBody))
+                $outcome .= "Site attributes updated\n";
+            $site->writeRecord();
+            $action = "created";
+        } else if ($site->updateFromEmail($this->emailBody)) {
+            error_log(
+                "EMAIL: updating site attributes : " . $site->name);
+            $outcome .= "Site attributes updated\n";
+            $site->writeRecord();
+        }
+
+        if (count($newSiteIPs) > 0) {
+            error_log(
+                "EMAIL: Adding client IP addresses : " . $site->name);
+            $outcome .= count($newSiteIPs) . " RADIUS IP Addresses added\n";
+            $site->addIPs($newSiteIPs);
+        }
+
+        if (count($newSiteSourceIPs) > 0) {
+            error_log(
+                "EMAIL: Adding source IP addresses : " . $site->name);
+            $outcome .=
+                count($newSiteIPs) . " Source IP Address ranges added\n";
+            $site->addSourceIPs($newSiteSourceIPs);
+        }
+
+        $email->newSite($action, $outcome, $site);
+        // Create the site information pdf
+        $pdf = new PDF();
+        $pdf->populateNewSite($site);
+        $report = new Report;
+        $report->orgAdmin = $orgAdmin;
+        $report->getIPList($site);
+        $pdf->generatePDF($report);
+        $email->fileName = $pdf->filename;
+        $email->filePath = $pdf->filepath;
+        $email->send($orgAdmin->emailManagerAddress);
+
+        // Create sms response for the code
+        $sms = new SmsResponse($orgAdmin->mobile);
+        $sms->sendNewsitePassword($pdf);
     }
 
     /**

--- a/src/EmailResponse.php
+++ b/src/EmailResponse.php
@@ -57,9 +57,9 @@ class EmailResponse {
         $this->replaceInMessages("%ATTRIBUTES%", $site->attributesText());
     }
 
-    public function newSiteBlank($site) {
+    public function newSiteBlank($subject) {
         $config = Config::getInstance();
-        $this->subject = $site->name;
+        $this->subject = $subject;
         $this->setMessages($config->values['email-messages']['newsite-help-file']);
     }
 

--- a/src/timedjobs/survey/index.php
+++ b/src/timedjobs/survey/index.php
@@ -1,10 +1,10 @@
 <?php
 namespace Alphagov\GovWifi;
 
-require "../../common.php";
+require dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . "common.php";
 
 
-if (Config::getInstance()->values["frontendApiKey"] == $_REQUEST['key']) {
+if (!empty($_REQUEST['key']) && Config::getInstance()->values["frontendApiKey"] == $_REQUEST['key']) {
     $survey = new Survey([
         'config' => Config::getInstance(),
         'db'     => DB::getInstance()

--- a/templates/email/html/wifi-details-20170308
+++ b/templates/email/html/wifi-details-20170308
@@ -9,7 +9,7 @@
 
 <p>When you arrive at a government building where GovWifi is available, go to your wifi settings, select GovWifi and enter your details.</p>
 
-<p>Scroll down to find instructions for your device.</p>
+<p>Scroll down to find instructions for your device, or view the instructions online: https://www.gov.uk/govwifi</p>
 
 
 <h3 id="android">Android devices:</h3>

--- a/templates/email/html/wifi-details-20170308
+++ b/templates/email/html/wifi-details-20170308
@@ -9,7 +9,7 @@
 
 <p>When you arrive at a government building where GovWifi is available, go to your wifi settings, select GovWifi and enter your details.</p>
 
-<p>Scroll down to find instructions for your device, or view the instructions online: https://www.gov.uk/govwifi</p>
+<p>Scroll down to find instructions for your device, or view the instructions online:&nbsp;<a href="https://www.gov.uk/govwifi">https://www.gov.uk/govwifi</a></p>
 
 
 <h3 id="android">Android devices:</h3>

--- a/templates/email/html/wifi-details-20170308
+++ b/templates/email/html/wifi-details-20170308
@@ -13,11 +13,11 @@
 
 
 <h3 id="android">Android devices:</h3>
-<p>In your wifi settings (scroll down):</p>
+<p>In your wifi settings:</p>
 <ol>
 <li> In the <strong>EAP method</strong> field, select <strong>PEAP</strong>.</li>
 <li> In the <strong>Phase 2 authentication</strong> field, select <strong>MSCHAPV2</strong>.</li>
-<li> Enter your username (in the <strong>Identity</strong> field) and password.</li>
+<li> Enter your username (in the <strong>Identity</strong> field), scroll down and enter your password.</li>
 </ol>
 <p>Having problems connecting? Contact the helpdesk in your building. Ask for details from the person who invited you to connect to GovWifi.</p>
 <p>&nbsp;</p>

--- a/templates/email/html/wifi-details-self-signup-20170308
+++ b/templates/email/html/wifi-details-self-signup-20170308
@@ -9,7 +9,7 @@
 
 <p>When you arrive at a government building where GovWifi is available, go to your wifi settings, select GovWifi and enter your details.</p>
 
-<p>Scroll down to find instructions for your device.</p>
+<p>Scroll down to find instructions for your device, or view the instructions online: https://www.gov.uk/govwifi</p>
 
 
 <h3 id="android">Android devices:</h3>

--- a/templates/email/html/wifi-details-self-signup-20170308
+++ b/templates/email/html/wifi-details-self-signup-20170308
@@ -13,11 +13,11 @@
 
 
 <h3 id="android">Android devices:</h3>
-<p>In your wifi settings (scroll down):</p>
+<p>In your wifi settings:</p>
 <ol>
 <li> In the <strong>EAP method</strong> field, select <strong>PEAP</strong>.</li>
 <li> In the <strong>Phase 2 authentication</strong> field, select <strong>MSCHAPV2</strong>.</li>
-<li> Enter your username (in the <strong>Identity</strong> field) and password.</li>
+<li> Enter your username (in the <strong>Identity</strong> field), scroll down and enter your password.</li>
 </ol>
 <p>Having problems connecting? Contact the helpdesk in your building. </p>
 <p>&nbsp;</p>

--- a/templates/email/html/wifi-details-self-signup-20170308
+++ b/templates/email/html/wifi-details-self-signup-20170308
@@ -9,7 +9,7 @@
 
 <p>When you arrive at a government building where GovWifi is available, go to your wifi settings, select GovWifi and enter your details.</p>
 
-<p>Scroll down to find instructions for your device, or view the instructions online: https://www.gov.uk/govwifi</p>
+<p>Scroll down to find instructions for your device, or view the instructions online:&nbsp;<a href="https://www.gov.uk/govwifi">https://www.gov.uk/govwifi</a></p>
 
 
 <h3 id="android">Android devices:</h3>

--- a/templates/email/logrequest
+++ b/templates/email/logrequest
@@ -1,2 +1,7 @@
 The logs you requested are in the attached PDF %FILENAME%.
-If the data is sensitive, we've encrypted the file and sent the password to the mobile number we have on record for you.
+If the data is sensitive, the file is encrypted. - Use the password we sent to your mobile phone to decrypt the file.
+
+For help, email govwifi-support@digital.cabinet-office.gov.uk
+
+Regards,
+The GovWifi team

--- a/templates/email/newsite
+++ b/templates/email/newsite
@@ -8,3 +8,8 @@ The site attributes for %NAME% are:
 %ATTRIBUTES%
 
 You can edit these attributes and reply to this email.
+
+For help, email govwifi-support@digital.cabinet-office.gov.uk
+
+Regards,
+The GovWifi team

--- a/templates/email/newsite-help
+++ b/templates/email/newsite-help
@@ -1,3 +1,14 @@
-Thank you for requesting a new Wi-Fi site. No IP addresses were found in your email. Please write one IP address per line in the message text with no other spaces or characters.
-The IP address may be registered to another site. If you share your internet connection with another department, check whether they have already registered the IP address to GovWifi.
-We’ve attached an encrypted PDF %FILENAME% which contains the current configuration for this site. Use the password we’ve sent to your mobile to decrypt the file.
+Hello,
+
+Thank you for requesting a new wifi site.
+
+Unfortunately, we didn’t recognise any IP addresses in your email.
+Please send a new email to newsite@wifi.service.gov.uk. Provide one or more IP address, one per line, with no extra spaces or characters.
+
+The IP address you provided may be registered for another site. If you share your internet connection with another department, check whether they’ve already registered the IP address for GovWifi.
+
+For help, email govwifi-support@digital.cabinet-office.gov.uk.
+
+Regards,
+The GovWifi team
+

--- a/templates/email/wifi-details-20170308
+++ b/templates/email/wifi-details-20170308
@@ -10,8 +10,8 @@ Your password: %PASS%
 
 When you arrive at a government building where GovWifi is available, go to your wifi settings, select GovWifi and enter your details.
 
-Scroll down to find instructions for your device.
-
+Scroll down to find instructions for your device, or view the instructions online:
+https://www.gov.uk/govwifi
 
 Android devices:
 

--- a/templates/email/wifi-details-20170308
+++ b/templates/email/wifi-details-20170308
@@ -15,10 +15,10 @@ Scroll down to find instructions for your device.
 
 Android devices:
 
-In your wifi settings (scroll down):
+In your wifi settings:
 1. In the EAP method field, select PEAP.
 2. In the Phase 2 authentication field, select MSCHAPV2.
-3. Enter your username (in the Identity field) and password.
+3. Enter your username (in the Identity field), scroll down and enter your password.
 
 Having problems connecting? Contact the helpdesk in your building.
 

--- a/templates/email/wifi-details-self-signup-20170308
+++ b/templates/email/wifi-details-self-signup-20170308
@@ -10,7 +10,8 @@ Your password: %PASS%
 
 When you arrive at a government building where GovWifi is available, go to your wifi settings, select GovWifi and enter your details.
 
-Scroll down to find instructions for your device.
+Scroll down to find instructions for your device, or view the instructions online:
+https://www.gov.uk/govwifi
 
 
 Android devices:

--- a/templates/email/wifi-details-self-signup-20170308
+++ b/templates/email/wifi-details-self-signup-20170308
@@ -15,10 +15,10 @@ Scroll down to find instructions for your device.
 
 Android devices:
 
-In your wifi settings (scroll down):
+In your wifi settings:
 1. In the EAP method field, select PEAP.
 2. In the Phase 2 authentication field, select MSCHAPV2.
-3. Enter your username (in the Identity field) and password.
+3. Enter your username (in the Identity field), scroll down and enter your password.
 
 Having problems connecting? Contact the helpdesk in your building. Ask for details from the person who invited you to connect to GovWifi.
 


### PR DESCRIPTION
- Update admin email copies to latest version
- Change newsite logic: not to send PDF with help email; actually send the help email when IPs are not found in the first newsite request.
- Change android help text - emphasise scroll down and logically separate password 
- Add link to online instructions at the beginning of the email