### PR TITLE
PerformancePlatform report updates.

### DIFF
--- a/src/PerformancePlatformClient.php
+++ b/src/PerformancePlatformClient.php
@@ -107,6 +107,8 @@ class PerformancePlatformClient {
             $extras,
             $data);
 
+        error_log("PerformancePlatform payload: " . json_encode($payload));
+
         try {
             $response = $this->httpPostJson($this->buildUrl($config['dataType']), $config['bearerToken'], $payload);
             error_log("PerformancePlatform response: " .

--- a/src/PerformancePlatformReport.php
+++ b/src/PerformancePlatformReport.php
@@ -62,6 +62,8 @@ abstract class PerformancePlatformReport {
      * @param array $params
      */
     protected function sendSimpleMetric($params) {
+        error_log("PerformancePlatform report sendSimpleMetrics called for [" . $this->getMetricName() . "]");
+
         $dateObject = new DateTime();
         $params = array_merge([
             'timestamp'     => $dateObject->sub(new DateInterval('P1D'))->format('Y-m-d') . 'T00:00:00+00:00',

--- a/src/ReportAccountUsage.php
+++ b/src/ReportAccountUsage.php
@@ -40,7 +40,8 @@ class ReportAccountUsage extends PerformancePlatformReport {
         $this->sendSimpleMetric(array_merge($defaults, [
             'extras' => [ 'type' => 'total' ],
             'data'   => [
-                'count' => $total
+                'count' => $total,
+                'transactionsCount' => $perSite
             ]
         ]));
 

--- a/src/ReportAccountUsage.php
+++ b/src/ReportAccountUsage.php
@@ -40,8 +40,7 @@ class ReportAccountUsage extends PerformancePlatformReport {
         $this->sendSimpleMetric(array_merge($defaults, [
             'extras' => [ 'type' => 'total' ],
             'data'   => [
-                'count' => $total,
-                'transactionsCount' => $perSite
+                'count' => $total
             ]
         ]));
 
@@ -56,6 +55,13 @@ class ReportAccountUsage extends PerformancePlatformReport {
             'extras' => [ 'type' => 'one-time' ],
             'data'   => [
                 'count' => $total - $roaming
+            ]
+        ]));
+
+        $this->sendSimpleMetric(array_merge($defaults, [
+            'extras' => [ 'type' => 'transactions' ],
+            'data'   => [
+                'count' => $perSite
             ]
         ]));
     }

--- a/src/ReportCompletionRate.php
+++ b/src/ReportCompletionRate.php
@@ -62,7 +62,7 @@ class ReportCompletionRate extends PerformancePlatformReport {
 
             // Number of users successfully logged in from the list above
             $this->sendSimpleMetric(array_merge($defaults, [
-                array_merge(
+                'extras' => array_merge(
                     [ 'stage' => 'complete' ],
                     $channel['extras']
                 ),

--- a/src/sms/index.php
+++ b/src/sms/index.php
@@ -8,7 +8,7 @@ $smsReq = new SmsRequest(Config::getInstance());
 // FireText uses source, message, and keyword
 // for short numbers keyword is set to the keyword entered,
 // otherwise it's a string constant.
-error_log(var_export($_REQUEST, true));
+
 $sender = "";
 if (isset($_REQUEST['sender'])) {
     $sender = $_REQUEST['sender'];

--- a/src/timedjobs/performanceplatform/index.php
+++ b/src/timedjobs/performanceplatform/index.php
@@ -48,4 +48,6 @@ if (! empty($_REQUEST['key']) && Config::getInstance()->values["frontendApiKey"]
     }
 } else if (! strtolower(substr(php_sapi_name(), 0, 3)) === 'cli') {
     header("HTTP/1.1 404 Not Found");
+} else {
+    echo strtolower(substr(php_sapi_name(), 0, 3));
 }

--- a/src/timedjobs/performanceplatform/index.php
+++ b/src/timedjobs/performanceplatform/index.php
@@ -6,10 +6,7 @@ require dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . "common.php";
 use DateInterval;
 use DateTime;
 
-error_log("sapi name:" . strtolower(substr(php_sapi_name(), 0, 3)));
-
 if (! empty($_REQUEST['key']) && Config::getInstance()->values["frontendApiKey"] === $_REQUEST['key']) {
-    error_log("hit true");
     $period = "daily";
     if (! empty($_REQUEST['period'])) {
         $period = $_REQUEST['period'];
@@ -49,10 +46,6 @@ if (! empty($_REQUEST['key']) && Config::getInstance()->values["frontendApiKey"]
         case "monthly":
             break;
     }
-} else if (! strtolower(substr(php_sapi_name(), 0, 3)) === 'cli') {
-    error_log("hit false");
+} else if (! (strtolower(substr(php_sapi_name(), 0, 3)) === 'cli')) {
     header("HTTP/1.1 404 Not Found");
-} else {
-    error_log("hit else");
-    echo strtolower(substr(php_sapi_name(), 0, 3));
 }

--- a/src/timedjobs/performanceplatform/index.php
+++ b/src/timedjobs/performanceplatform/index.php
@@ -6,7 +6,10 @@ require dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . "common.php";
 use DateInterval;
 use DateTime;
 
+error_log("sapi name:" . strtolower(substr(php_sapi_name(), 0, 3)));
+
 if (! empty($_REQUEST['key']) && Config::getInstance()->values["frontendApiKey"] === $_REQUEST['key']) {
+    error_log("hit true");
     $period = "daily";
     if (! empty($_REQUEST['period'])) {
         $period = $_REQUEST['period'];
@@ -47,7 +50,9 @@ if (! empty($_REQUEST['key']) && Config::getInstance()->values["frontendApiKey"]
             break;
     }
 } else if (! strtolower(substr(php_sapi_name(), 0, 3)) === 'cli') {
+    error_log("hit false");
     header("HTTP/1.1 404 Not Found");
 } else {
+    error_log("hit else");
     echo strtolower(substr(php_sapi_name(), 0, 3));
 }

--- a/src/timedjobs/performanceplatform/index.php
+++ b/src/timedjobs/performanceplatform/index.php
@@ -23,8 +23,8 @@ if (! empty($_REQUEST['key']) && Config::getInstance()->values["frontendApiKey"]
                     $dateObject = new DateTime();
                     $reportDate = $dateObject->sub(new DateInterval('P' . $i. 'D'))->format('Y-m-d');
                     // $reportVolumetrics->sendMetrics($reportDate); - report initialised.
-                    // $reportAccountUsage->sendMetrics($reportDate);
-                    $reportActiveLocations->sendMetrics($reportDate);
+                    $reportAccountUsage->sendMetrics($reportDate);
+                    //$reportActiveLocations->sendMetrics($reportDate);
                 }
             } else {
                 $reportVolumetrics->sendMetrics();

--- a/src/timedjobs/performanceplatform/index.php
+++ b/src/timedjobs/performanceplatform/index.php
@@ -36,8 +36,8 @@ if (! empty($_REQUEST['key']) && Config::getInstance()->values["frontendApiKey"]
             $reportCompletionRate = new ReportCompletionRate(Config::getInstance(), DB::getInstance());
             $reportUniqueUsers = new ReportUniqueUsers(Config::getInstance(), DB::getInstance());
             if (! empty($_REQUEST['date'])) {
-                // $reportCompletionRate->sendMetrics($_REQUEST['date']);
-                $reportUniqueUsers->sendMetrics($_REQUEST['date']);
+                $reportCompletionRate->sendMetrics($_REQUEST['date']);
+                //$reportUniqueUsers->sendMetrics($_REQUEST['date']);
             } else {
                 $reportCompletionRate->sendMetrics();
                 $reportUniqueUsers->sendMetrics();

--- a/src/timedjobs/performanceplatform/index.php
+++ b/src/timedjobs/performanceplatform/index.php
@@ -36,8 +36,8 @@ if (! empty($_REQUEST['key']) && Config::getInstance()->values["frontendApiKey"]
             $reportCompletionRate = new ReportCompletionRate(Config::getInstance(), DB::getInstance());
             $reportUniqueUsers = new ReportUniqueUsers(Config::getInstance(), DB::getInstance());
             if (! empty($_REQUEST['date'])) {
-                $reportCompletionRate->sendMetrics($_REQUEST['date']);
-                //$reportUniqueUsers->sendMetrics($_REQUEST['date']);
+                //$reportCompletionRate->sendMetrics($_REQUEST['date']);
+                $reportUniqueUsers->sendMetrics($_REQUEST['date']);
             } else {
                 $reportCompletionRate->sendMetrics();
                 $reportUniqueUsers->sendMetrics();

--- a/src/timedjobs/survey/index.php
+++ b/src/timedjobs/survey/index.php
@@ -9,6 +9,6 @@ if (! empty($_REQUEST['key']) && Config::getInstance()->values["frontendApiKey"]
         'db'     => DB::getInstance()
     ]);
     $survey->sendSurveys();
-} else if (! strtolower(substr(php_sapi_name(), 0, 3)) === 'cli') {
+} else if (! (strtolower(substr(php_sapi_name(), 0, 3)) === 'cli')) {
     header("HTTP/1.1 404 Not Found");
 }


### PR DESCRIPTION
- Add extra logging for the sendSimpleMetrics call in PP report.
- Add number of transactions (number of users per site per day) to account usage stats, allow data reinitialisation.
- Rewrite unique users to calculate the averages directly and skip weekends.