### PR TITLE
Performance Platform fix for active users

### DIFF
--- a/src/ReportUniqueUsers.php
+++ b/src/ReportUniqueUsers.php
@@ -41,7 +41,7 @@ class ReportUniqueUsers extends PerformancePlatformReport {
 
         $lastMonthStart = (new DateTime($today))->sub(new DateInterval('P1M'))->format('Y-m-01');
         $thisMonthStart = (new DateTime($today))->format('Y-m-01');
-        $perMonthSql = "SELECT sum(users)/count(*) DIV 1 as `month-count` FROM (" .
+        $perMonthSql = "SELECT sum(users)/count(*) DIV 1 as `month_count` FROM (" .
                 "SELECT date(start) AS day, count(distinct(username)) AS users FROM session " .
                 "WHERE start BETWEEN '" . $lastMonthStart . "' AND '" . $thisMonthStart . "' ".
                 "AND dayofweek(start) NOT IN (1,7) GROUP BY day" .

--- a/src/ReportUniqueUsers.php
+++ b/src/ReportUniqueUsers.php
@@ -41,13 +41,13 @@ class ReportUniqueUsers extends PerformancePlatformReport {
 
         $lastMonthStart = (new DateTime($today))->sub(new DateInterval('P1M'))->format('Y-m-01');
         $thisMonthStart = (new DateTime($today))->format('Y-m-01');
-        $perMonthSql = "SELECT sum(users)/count(*) DIV 1 as `count` FROM (" .
+        $perMonthSql = "SELECT sum(users)/count(*) DIV 1 as `month-count` FROM (" .
                 "SELECT date(start) AS day, count(distinct(username)) AS users FROM session " .
                 "WHERE start BETWEEN '" . $lastMonthStart . "' AND '" . $thisMonthStart . "' ".
                 "AND dayofweek(start) NOT IN (1,7) GROUP BY day" .
             ") foo;";
         $this->sendSimpleMetric([
-            'timestamp' => $thisMonthStart . 'T00:00:00+00:00',
+            'timestamp' => $lastMonthStart . 'T00:00:00+00:00',
             'sql'       => $perMonthSql,
             'period'    => 'month'
         ]);


### PR DESCRIPTION
- Rename month field, send prev month start as timestamp for unique users stat. This allows for more consistent separation of data and fixes the date range it corresponds to.