### PR TITLE
Handle malformed Acct-Session-Ids

### DIFF
--- a/src/AAA.php
+++ b/src/AAA.php
@@ -203,10 +203,16 @@ class AAA {
         $this->responseHeader = self::HTTP_RESPONSE_NOT_FOUND;
 
         if (! in_array($accountingType, self::ACCEPTED_ACCOUNTING_TYPES)) {
-            // Silently fail if the accounting request type is not recognized.
             error_log("Accounting request type not recognised: [" . $accountingType . "]");
             return;
         }
+
+        if (! $this->user->validUser) {
+            error_log("Skip Accounting [" . $accountingType .
+                "] for invalid user [" . $this->user->login . "]");
+            return;
+        }
+
         $this->session = new Session(
                 $this->user->login . md5($acct['Acct-Session-Id']['value'][0]),
                 Cache::getInstance());

--- a/src/AAA.php
+++ b/src/AAA.php
@@ -208,7 +208,7 @@ class AAA {
             return;
         }
         $this->session = new Session(
-                $this->user->login . $acct['Acct-Session-Id']['value'][0],
+                $this->user->login . md5($acct['Acct-Session-Id']['value'][0]),
                 Cache::getInstance());
 
         error_log("Acct type: " . $accountingType);

--- a/tests/unit/UserTest.php
+++ b/tests/unit/UserTest.php
@@ -32,4 +32,28 @@ class UserTest extends PHPUnit_Framework_TestCase {
         $userName = $user->generateRandomUsername();
         self::assertEquals(strtolower($userName), $userName);
     }
+
+    function testLoadRecordWifhExistingUser() {
+        $user = new User(Cache::getInstance(), Config::getInstance());
+        $user->login = TestConstants::getInstance()->getUnitTestUserName();
+        $user->loadRecord();
+        self::assertTrue($user->validUser);
+        self::assertEquals(TestConstants::getInstance()->getUnitTestUserPassword(), $user->password);
+    }
+
+    function testLoadRecordWifhNonExistingUser() {
+        $user = new User(Cache::getInstance(), Config::getInstance());
+        $user->login = "RANDO1";
+        $user->loadRecord();
+        self::assertFalse($user->validUser);
+        self::assertEquals("", $user->password);
+    }
+
+    function testLoadRecordWifhNonExistingUserWithForce() {
+        $user = new User(Cache::getInstance(), Config::getInstance());
+        $user->login = "RANDO2";
+        $user->loadRecord(true);
+        self::assertTrue($user->validUser);
+        self::assertNotEmpty($user->password);
+    }
 }


### PR DESCRIPTION
- Calculate the md5 hash of the session ID instead of appending it directly to the username when constructing the key for the cache (memcached).

If the key is malformed - contains a space or other special character -  when saving data to memcached the process will hang indefinitely instead of returning an error (and eventually execution timeout kicks in at 30 seconds). Using the hex representation of the md5 hash this can not happen. Considering the random nature of the of the actual session IDs and the fact that the username is prepended to the final key the chance of key clash is negligible. 

- Skip starting an accounting session for invalid users.