### PR TITLE
Update session record with building identifier on accounting

### DIFF
--- a/src/AAA.php
+++ b/src/AAA.php
@@ -222,15 +222,17 @@ class AAA {
             case self::ACCOUNTING_TYPE_START:
             case self::ACCOUNTING_TYPE_ON:
                 // Acct Start - Store session in Memcache
-                $this->session->login = $this->user->login;
-                $this->session->startTime = time();
                 $this->setMac($acct['Calling-Station-Id']['value'][0]);
                 $this->setAp($acct['Called-Station-Id']['value'][0]);
-                $this->session->mac = $this->getMac();
-                $this->session->ap = $this->getAp();
+
+                $this->session->login              = $this->user->login;
+                $this->session->startTime          = time();
+                $this->session->mac                = $this->getMac();
+                $this->session->ap                 = $this->getAp();
                 $this->session->buildingIdentifier = $this->buildingIdentifier;
-                $this->session->siteIP = $this->siteIP;
+                $this->session->siteIP             = $this->siteIP;
                 $this->session->writeToCache();
+                $this->session->writeToDB(false);
                 error_log(
                         "Accounting start: "
                         . "[" . $accountingType . "] "
@@ -380,12 +382,21 @@ class AAA {
     }
 
     /**
-     * Visible for testing
+     * Visible for testing.
      *
      * @return string
      */
     public function getBuildingIdentifier() {
         return $this->buildingIdentifier;
+    }
+
+    /**
+     * Visible for testing.
+     *
+     * @return string
+     */
+    public function getResponseHeader() {
+       return $this->responseHeader;
     }
 
     /**

--- a/src/AAA.php
+++ b/src/AAA.php
@@ -203,10 +203,16 @@ class AAA {
         $this->responseHeader = self::HTTP_RESPONSE_NOT_FOUND;
 
         if (! in_array($accountingType, self::ACCEPTED_ACCOUNTING_TYPES)) {
-            // Silently fail if the accounting request type is not recognized.
             error_log("Accounting request type not recognised: [" . $accountingType . "]");
             return;
         }
+
+        if (! $this->user->validUser) {
+            error_log("Skip Accounting [" . $accountingType .
+                "] for invalid user [" . $this->user->login . "]");
+            return;
+        }
+
         $this->session = new Session(
                 $this->user->login . md5($acct['Acct-Session-Id']['value'][0]),
                 Cache::getInstance());

--- a/src/AAA.php
+++ b/src/AAA.php
@@ -208,7 +208,7 @@ class AAA {
             return;
         }
         $this->session = new Session(
-                $this->user->login . $acct['Acct-Session-Id']['value'][0],
+                $this->user->login . md5($acct['Acct-Session-Id']['value'][0]),
                 Cache::getInstance());
 
         error_log("Acct type: " . $accountingType);

--- a/tests/TestConstants.php
+++ b/tests/TestConstants.php
@@ -13,13 +13,17 @@ class TestConstants {
     const HTTP_OK                         = "HTTP/1.1 200 OK";
     const HTTP_NO_DATA                    = "HTTP/1.0 204 OK";
     const HTTP_11_NO_DATA                 = "HTTP/1.1 204 OK";
+    const HTTP_11_NOT_FOUND               = "HTTP/1.1 404 Not Found";
     const HEALTH_CHECK_USER_PASSWORD      = 'GS3EWA64EshRD8I0XdVl$dko';
     const BACKEND_API_PORT                = "8080";
     const CLEARTEXT_PASSWORD_PLACEHOLDER  = "#CLEARTEXT_PASSWORD#";
+    const STATION_PLACEHOLDER             = "#CALLED_STATION_ID#";
+    const MAC_PLACEHOLDER                 = "#CALLING_STATION_ID#";
     const RESULT_PLACEHOLDER              = "#RESULT#";
     const AUTH_RESULT_ACCEPT              = "Access-Accept";
     const AUTH_RESULT_REJECT              = "Access-Reject";
     const BUILDING_ID                     = "AP-GROUP";
+    const ALTERNATIVE_BUILDING_ID         = "ALTERNATIVE-ID";
     const AUTHORIZATION_RESPONSE_TEMPLATE =
         "{\"control:Cleartext-Password\":\"" . self::CLEARTEXT_PASSWORD_PLACEHOLDER . "\"}";
     const USERNAME_PLACEHOLDER            = "#USERNAME#";
@@ -174,11 +178,18 @@ class TestConstants {
      *
      * @param string $accountingType
      * @param string $username
+     * @param string $calledStationId
+     * @param string $callingStationId
      * @return string the json data
      * @throws Exception if the accounting type is not in the list defined in class AAA,
      * or there's no file for the given type
      */
-    public static function getAccountingJsonForType($accountingType, $username) {
+    public static function getAccountingJsonForType(
+            $accountingType,
+            $username,
+            $calledStationId = "00-0c-29-89-85-d9",
+            $callingStationId = "8c-3a-e3-6c-65-d9") {
+
         if (!in_array($accountingType, AAA::ACCEPTED_ACCOUNTING_TYPES)) {
             throw new Exception("Accounting type not recognised. [" . $accountingType . "]");
         }
@@ -209,7 +220,15 @@ class TestConstants {
             str_replace(
                 self::TIMESTAMP_PLACEHOLDER,
                 date('M d Y H:i:s T', time()),
-                $jsonData
+                str_replace(
+                    self::STATION_PLACEHOLDER,
+                    $calledStationId,
+                    str_replace(
+                        self::MAC_PLACEHOLDER,
+                        $callingStationId,
+                        $jsonData
+                    )
+                )
             )
         );
     }

--- a/tests/acceptance/config/radius-accounting-start.json
+++ b/tests/acceptance/config/radius-accounting-start.json
@@ -26,13 +26,13 @@
     "Called-Station-Id": {
         "type": "string",
         "value": [
-            "00-0c-29-89-85-d9"
+            "#CALLED_STATION_ID#"
         ]
     },
     "Calling-Station-Id": {
         "type": "string",
         "value": [
-            "8c-3a-e3-6c-65-d9"
+            "#CALLING_STATION_ID#"
         ]
     },
     "NAS-Identifier": {

--- a/tests/unit/UserTest.php
+++ b/tests/unit/UserTest.php
@@ -32,4 +32,28 @@ class UserTest extends PHPUnit_Framework_TestCase {
         $userName = $user->generateRandomUsername();
         self::assertEquals(strtolower($userName), $userName);
     }
+
+    function testLoadRecordWifhExistingUser() {
+        $user = new User(Cache::getInstance(), Config::getInstance());
+        $user->login = TestConstants::getInstance()->getUnitTestUserName();
+        $user->loadRecord();
+        self::assertTrue($user->validUser);
+        self::assertEquals(TestConstants::getInstance()->getUnitTestUserPassword(), $user->password);
+    }
+
+    function testLoadRecordWifhNonExistingUser() {
+        $user = new User(Cache::getInstance(), Config::getInstance());
+        $user->login = "RANDO1";
+        $user->loadRecord();
+        self::assertFalse($user->validUser);
+        self::assertEquals("", $user->password);
+    }
+
+    function testLoadRecordWifhNonExistingUserWithForce() {
+        $user = new User(Cache::getInstance(), Config::getInstance());
+        $user->login = "RANDO2";
+        $user->loadRecord(true);
+        self::assertTrue($user->validUser);
+        self::assertNotEmpty($user->password);
+    }
 }


### PR DESCRIPTION
- Update all sessions on start and stop, not just stop. 
- Leave AP field intact (so for HO we should have both fields filled, for Plymouth, only the building ID)
- Possible issue: if Plymouth starts sending accounting requests (they don't at the moment) AND those accounting requests are not agreeing with the Access requests in their building ID (sending the AP instead) The previously (rightly) set building ID will be deleted from the record, while AP will not get set at all. 