### PR TITLE
AuthoriseResponse updates

### DIFF
--- a/src/AAA.php
+++ b/src/AAA.php
@@ -413,11 +413,14 @@ class AAA {
 
         // If this matches a user account continue
         if (isset($this->user->identifier)
-            && $this->user->identifier->text) {
+            && !empty($this->user->identifier->text)
+            && $this->user->validUser) {
             // Logic for restricted journey may come here
             // Eg test emails against specific regex, lock out SMS-registered users, etc.
             $this->authorizeResponse(TRUE);
+            return;
         }
+        $this->authorizeResponse(FALSE);
     }
 
     private function authorizeResponse($accept) {

--- a/src/User.php
+++ b/src/User.php
@@ -170,7 +170,11 @@ class User {
             $this->newPassword();
             $this->validUser = true;
         } else {
-            error_log("User record not found for username [" . $this->login . "]");
+            if (! empty($this->login)) {
+                error_log("User record not found for username [" . $this->login . "]");
+            } else {
+                error_log("User record not found for contact [" . $this->identifier->text . "]");
+            }
         }
     }
 

--- a/tests/unit/AAATest.php
+++ b/tests/unit/AAATest.php
@@ -86,6 +86,35 @@ class AAATest extends PHPUnit_Framework_TestCase {
         );
     }
 
+    function testProcessAuthorisationRequestNormalUser() {
+        $aaa = new AAA(TestConstants::authorisationUrlForUser(TestConstants::getInstance()->getUnitTestUserName()), "");
+        $this->assertEquals(
+            [
+                'headers' => [
+                    TestConstants::HTTP_OK,
+                    "Content-Type: application/json",
+                ],
+                'body' => TestConstants::authorisationResponseForPassword(
+                    TestConstants::getInstance()->getUnitTestUserPassword())
+            ],
+            $aaa->processRequest()
+        );
+    }
+
+    function testProcessAuthRejectRequestNormalUser() {
+        $aaa = new AAA(TestConstants::authorisationUrlForUser("INVALI"), "");
+        $this->assertEquals(
+            [
+                'headers' => [
+                    TestConstants::HTTP_11_NOT_FOUND,
+                    "Content-Type: application/json",
+                ],
+                'body' => ''
+            ],
+            $aaa->processRequest()
+        );
+    }
+
     function testProcessPostAuthRequestHealthCheckDoesNotStartASession() {
         $aaa = new AAA(TestConstants::postAuthUrlForUser(Config::HEALTH_CHECK_USER), "");
         $this->assertEquals(


### PR DESCRIPTION
- Make sure we are sending a negative instead of an empty response on authorisation failure. 
- Take into account the new "invalid user" setting. (in preparation for user invalidation)
- More tests.
- Fix error message for when the user is not found and looked for by contact instead of login.