### PR TITLE
Live release 20170817

### DIFF
--- a/src/AAA.php
+++ b/src/AAA.php
@@ -413,11 +413,14 @@ class AAA {
 
         // If this matches a user account continue
         if (isset($this->user->identifier)
-            && $this->user->identifier->text) {
+            && !empty($this->user->identifier->text)
+            && $this->user->validUser) {
             // Logic for restricted journey may come here
             // Eg test emails against specific regex, lock out SMS-registered users, etc.
             $this->authorizeResponse(TRUE);
+            return;
         }
+        $this->authorizeResponse(FALSE);
     }
 
     private function authorizeResponse($accept) {

--- a/src/User.php
+++ b/src/User.php
@@ -172,8 +172,10 @@ class User {
         } else {
             if (! empty($this->login)) {
                 error_log("User record not found for username [" . $this->login . "]");
-            } else {
+            } else if (isset($this->identifier)) {
                 error_log("User record not found for contact [" . $this->identifier->text . "]");
+            } else {
+                error_log("User record not found.");
             }
         }
     }

--- a/src/User.php
+++ b/src/User.php
@@ -170,7 +170,11 @@ class User {
             $this->newPassword();
             $this->validUser = true;
         } else {
-            error_log("User record not found for username [" . $this->login . "]");
+            if (! empty($this->login)) {
+                error_log("User record not found for username [" . $this->login . "]");
+            } else {
+                error_log("User record not found for contact [" . $this->identifier->text . "]");
+            }
         }
     }
 

--- a/templates/email/existing-user
+++ b/templates/email/existing-user
@@ -1,0 +1,5 @@
+Hello,
+
+Your existing username for connecting to GovWifi is: %LOGIN%
+
+To request a new password, send a blank email to newpass@wifi.service.gov.uk  

--- a/templates/email/html/existing-user
+++ b/templates/email/html/existing-user
@@ -1,0 +1,4 @@
+<p>Hello,</p>
+<p><strong>Your existing username for GovWifi is: %LOGIN%</strong><br />
+
+<p>To request a new password, send a blank email to <a href="newpass@wifi.service.gov.uk"> newpass@wifi.service.gov.uk </a> </p>

--- a/templates/email/html/newpassword
+++ b/templates/email/html/newpassword
@@ -1,0 +1,101 @@
+<p>Hello,</p>
+<p><strong>Your new password for connecting to GovWifi is: %PASS%</strong></p>
+
+<p>These details are unique to you. Your password is case sensitive. It&rsquo;s 3 words without spaces. The first letter of each word is capitalised.</p>
+
+<p>You should have received your username in a separate email. If you need it again, email <a href="signup@wifi.service.gov.uk">signup@wifi.service.gov.uk</a> </p>
+
+<p>When you arrive at a government building where GovWifi is available, go to your wifi settings, select GovWifi and enter your details.</p>
+
+<p>Once you&rsquo;ve successfully connected in one building, you&rsquo;ll automatically reconnect to GovWifi wherever it&rsquo;s available.</p>
+
+<p>Scroll down to find instructions for your device, or view the instructions with screenshots online:&nbsp;<a href="https://www.gov.uk/govwifi">https://www.gov.uk/govwifi</a></p>
+
+
+<h3 id="android">Android devices:</h3>
+<p>In your wifi settings:</p>
+<ol>
+<li> In the <strong>EAP method</strong> field, select <strong>PEAP</strong>.</li>
+<li> In the <strong>Phase 2 authentication</strong> field, select <strong>MSCHAPV2</strong>.</li>
+<li> Enter your username (in the <strong>Identity</strong> field), scroll down and enter your password.</li>
+</ol>
+<p>Having problems connecting? Contact the helpdesk in your building. </p>
+<p>&nbsp;</p>
+
+<h3 id="iphoneipad">iPhone or iPad:</h3>
+<p>In your wifi settings:</p>
+<ol>
+<li style="font-weight: 400;">Enter your username and password.</li>
+<li>The message <strong>Not trusted</strong> means your phone doesn&rsquo;t recognise this wifi network yet. Check that the certificate is&nbsp;called <strong><a href="#" style="text-decoration:none;color:#0B0C0C;cursor:text">wifi.service.gov.uk</a></strong> and that it is issued by <strong>GeoTrust DV SSL SHA256 CA</strong>.</li>
+<li>If it is, select <strong>Trust</strong> so your phone recognises the wifi network.</li>
+</ol>
+<p>Having problems connecting? Contact the helpdesk in your building. </p>
+<p>&nbsp;</p>
+
+
+<h3 id="mac">Mac, iMac or Macbook:</h3>
+<p>In your wifi settings:</p>
+<ol>
+<li>Enter your GovWifi username and password.</li>
+<li>Select <strong>Show Certificate</strong>, then check that the certificate is called <strong><a href="#" style="text-decoration:none;color:#0B0C0C;cursor:text">wifi.service.gov.uk</a></strong> and that it is issued by <strong>GeoTrust DV SSL SHA256 CA</strong>.</li>
+<li>If so, select <strong>Continue</strong>.</li>
+<li>Enter your computer password to save these settings.</li>
+</ol>
+<p>Having problems connecting? Contact the helpdesk in your building. </p>
+<p>&nbsp;</p>
+
+
+<h3 id="windows8or10">Windows 8 or 10:</h3>
+<p>In your wifi settings:</p>
+<ol>
+<li>Select <strong>GovWifi</strong>, then <strong>Connect</strong>.</li>
+<li>Enter your username and password and select <strong>OK</strong>.</li>
+<li>When you see <strong>Continue connecting</strong>, select <strong>Show certificate details</strong>.</li>
+<li>Check that the <strong>Server thumbprint</strong> ends in: 93 74 A5 15 5A</li>
+<li>If it matches, select <strong>Connect</strong>.</li>
+</ol>
+<p>Having problems connecting? Contact the helpdesk in your building. </p>
+<p>&nbsp;</p>
+
+
+<h3 id="windows7">Windows 7:</h3>
+<ol>
+<li style="font-weight: 400;">Open the <strong>Control Panel</strong> and select <strong>Network and Sharing Center</strong>.</li>
+<li style="font-weight: 400;">Select <strong>Set up a new connection or network</strong>.</li>
+<li style="font-weight: 400;">Select <strong>Manually connect to a wireless network</strong>.</li>
+<li style="font-weight: 400;">In the <strong>Network name</strong> field, enter <strong>GovWifi</strong> and for the <strong>Security type</strong>, select <strong>WPA2-Enterprise</strong>.</li>
+<li style="font-weight: 400;">Select <strong>Next</strong>.</li>
+<li style="font-weight: 400;">Select <strong>Change connection settings</strong>.</li>
+<li style="font-weight: 400;">Select the <strong>Security</strong> tab and select <strong>Settings</strong>.</li>
+<li style="font-weight: 400;">Tick the <strong>Connect to these servers</strong> box. In the text box below it, enter <strong><a href="#" style="text-decoration:none;color:#0B0C0C;cursor:text">wifi.service.gov.uk</a></strong></li>
+<li style="font-weight: 400;">In the <strong>Trusted Root Certification Authorities</strong> list, select <strong>GeoTrust Primary Certification Authority - G3</strong>.</li>
+<li style="font-weight: 400;">Tick <strong>Enable Identity Privacy</strong> and enter <strong>anonymous</strong> to prevent your device from broadcasting your GovWifi username.</li>
+<li style="font-weight: 400;">Select <strong>Configure</strong>.</li>
+<li style="font-weight: 400;">Untick <strong>Automatically use my Windows logon name</strong>.</li>
+<li style="font-weight: 400;">Select <strong>OK</strong>, then <strong>OK</strong> again to go back to the <strong>GovWifi Wireless Network Properties</strong> window.</li>
+<li style="font-weight: 400;">Select <strong>Advanced settings</strong>.</li>
+<li style="font-weight: 400;">Select <strong>User authentication</strong> from the dropdown menu under <strong>Specify authentication mode</strong>, then select <strong>Save credentials</strong>.</li>
+<li style="font-weight: 400;">Enter your GovWifi username and password.</li>
+<li style="font-weight: 400;">Select <strong>OK</strong> to close all windows.</li>
+<li style="font-weight: 400;">Select the wifi logo at the bottom right of your screen and select <strong>GovWifi</strong>.</li>
+</ol>
+<p>Having problems connecting? Contact the helpdesk in your building. </p>
+<p>&nbsp;</p>
+
+
+<h3 id="chromebook">Chromebook:</h3>
+<p>In your advanced wifi settings:</p>
+<ol>
+<li style="font-weight: 400;">In the <strong>SSID</strong> field, enter <strong>GovWifi</strong>.</li>
+<li style="font-weight: 400;">In the <strong>EAP</strong> field, select <strong>PEAP</strong>.</li>
+<li style="font-weight: 400;">In the <strong>Phase-2 authentication</strong> field, select <strong>MSCHAPV2</strong>.</li>
+<li style="font-weight: 400;">In the <strong>Server CA certificate</strong> field, select <strong>Default</strong>.</li>
+<li style="font-weight: 400;">In the <strong>Identity</strong> field, enter your GovWifi username.</li>
+<li style="font-weight: 400;">In the <strong>Password</strong> field, enter your GovWifi password.</li>
+<li style="font-weight: 400;">Tick the <strong>Save identity and password</strong> box.</li>
+<li style="font-weight: 400;">Select <strong>Connect</strong>.</li>
+</ol>
+<p>Having problems connecting? Contact the helpdesk in your building. </p>
+<p>&nbsp;</p>
+
+<p>By connecting to GovWifi, you agree to the terms and conditions:&nbsp;<a href="https://www.gov.uk/govwifi">https://www.gov.uk/govwifi</a></p>

--- a/templates/email/newpassword
+++ b/templates/email/newpassword
@@ -1,0 +1,101 @@
+Hello,
+
+Your new password for connecting to GovWifi is: %PASS%
+
+These details are unique to you. Your password is case sensitive. It’s 3 words without spaces. The first letter of each word is capitalised.
+
+You should have received your username in a separate email. If you need it again, email signup@wifi.service.gov.uk
+
+When you arrive at a government building where GovWifi is available, go to your wifi settings, select GovWifi and enter your details.
+
+Once you’ve successfully connected in one building, you’ll automatically reconnect to GovWifi wherever it’s available.
+
+Scroll down to find instructions for your device, or view the instructions with screenshots online:
+https://www.gov.uk/govwifi
+
+Android devices:
+
+In your wifi settings:
+1. In the EAP method field, select PEAP.
+2. In the Phase 2 authentication field, select MSCHAPV2.
+3. Enter your username (in the Identity field), scroll down and enter your password.
+
+Having problems connecting? Contact the helpdesk in your building.
+
+
+iPhone or iPad instructions:
+
+In your wifi settings:
+1. Enter your username and password.
+2. The message Not trusted means your phone doesn’t recognise this wifi network yet. Check that the certificate is called:
+wifi.service.gov.uk
+and that it's issued by:
+GeoTrust DV SSL SHA256 CA
+3. If it is, select Trust so your phone recognises the wifi network.
+
+Having problems connecting? Contact the helpdesk in your building.
+
+
+Mac, iMac or Macbook:
+
+In your wifi settings:
+1. Enter your GovWifi username and password.
+2. Select Show Certificate, then check that the certificate is called:
+wifi.service.gov.uk
+and that it's issued by:
+GeoTrust DV SSL SHA256 CA.
+3. If so, select Continue.
+4. Enter your computer password to save these settings.
+
+Having problems connecting? Contact the helpdesk in your building.
+
+
+Windows 8 or 10:
+
+In your wifi settings:
+1. Select GovWifi, then Connect.
+2. Enter your username and password and select OK.
+3. When you see Continue connecting, select Show certificate details.
+4. Check that the Server thumbprint ends in: 93 74 A5 15 5A
+5. If it matches, select Connect.
+
+Having problems connecting? Contact the helpdesk in your building.
+
+
+Windows 7:
+1. Open the Control Panel, and select Network and Sharing Center.
+2. Select Set up a new connection or network.
+3. Select Manually connect to a wireless network.
+4. In the Network name field, enter GovWifi and for the Security type, select WPA2-Enterprise.
+5. Select Next.
+6. Select Change connection settings.
+7. Select the Security tab and select Settings.
+8. Tick the Connect to these servers box. In the text box below it, enter wifi.service.gov.uk
+9. In the Trusted Root Certification Authorities list, select GeoTrust Primary Certification Authority - G3.
+10. Tick Enable Identity Privacy and enter anonymous to prevent your device from broadcasting your GovWifi username.
+11. Select Configure.
+12. Untick Automatically use my Windows logon name.
+13. Select OK, then OK again to go back to the GovWifi Wireless Network Properties window.
+14. Select Advanced settings.
+15. Select User authentication from the dropdown menu under Specify authentication mode, then select Save credentials.
+16. Enter your GovWifi username and password.
+17. Select OK to close all windows.
+18. Select the wifi logo at the bottom right of your screen and select GovWifi.
+
+Having problems connecting? Contact the helpdesk in your building.
+
+
+Chromebook:
+1. In your advanced wifi settings:
+2. In the SSID field, enter GovWifi.
+3. In the EAP field, select PEAP.
+4. In the Phase-2 authentication field, select MSCHAPV2.
+5. In the Server CA certificate field, select Default.
+6. In the Identity field, enter your GovWifi username.
+7. In the Password field, enter your GovWifi password.
+8. Tick the Save identity and password box.
+9. Select Connect.
+
+Having problems connecting? Contact the helpdesk in your building.
+
+By connecting to GovWifi, you agree to the terms and conditions: https://www.gov.uk/govwifi

--- a/tests/unit/AAATest.php
+++ b/tests/unit/AAATest.php
@@ -86,6 +86,35 @@ class AAATest extends PHPUnit_Framework_TestCase {
         );
     }
 
+    function testProcessAuthorisationRequestNormalUser() {
+        $aaa = new AAA(TestConstants::authorisationUrlForUser(TestConstants::getInstance()->getUnitTestUserName()), "");
+        $this->assertEquals(
+            [
+                'headers' => [
+                    TestConstants::HTTP_OK,
+                    "Content-Type: application/json",
+                ],
+                'body' => TestConstants::authorisationResponseForPassword(
+                    TestConstants::getInstance()->getUnitTestUserPassword())
+            ],
+            $aaa->processRequest()
+        );
+    }
+
+    function testProcessAuthRejectRequestNormalUser() {
+        $aaa = new AAA(TestConstants::authorisationUrlForUser("INVALI"), "");
+        $this->assertEquals(
+            [
+                'headers' => [
+                    TestConstants::HTTP_11_NOT_FOUND,
+                    "Content-Type: application/json",
+                ],
+                'body' => ''
+            ],
+            $aaa->processRequest()
+        );
+    }
+
     function testProcessPostAuthRequestHealthCheckDoesNotStartASession() {
         $aaa = new AAA(TestConstants::postAuthUrlForUser(Config::HEALTH_CHECK_USER), "");
         $this->assertEquals(


### PR DESCRIPTION
- New email templates for password journey
- AuthoriseResponse updates
- Fix for suppressing warning when the identifier is not set (happens for HO test accounting requests)