### PR TITLE
Reduce risk of deadlock on accounting update

### DIFF
--- a/src/AAA.php
+++ b/src/AAA.php
@@ -232,7 +232,9 @@ class AAA {
                 $this->session->buildingIdentifier = $this->buildingIdentifier;
                 $this->session->siteIP             = $this->siteIP;
                 $this->session->writeToCache();
-                $this->session->writeToDB(false);
+                if (! empty($this->buildingIdentifier)) {
+                    $this->session->writeToDB(false);
+                }
                 error_log(
                         "Accounting start: "
                         . "[" . $accountingType . "] "

--- a/src/Session.php
+++ b/src/Session.php
@@ -98,6 +98,7 @@ class Session {
         if (! empty($this->ap)) {
             $addAP = true;
             $apText = " and ap=:ap ";
+            error_log("Added AP: [" . $this->ap. "]");
         }
         $db = DB::getInstance();
         $dbLink = $db->getConnection();

--- a/src/Session.php
+++ b/src/Session.php
@@ -93,13 +93,19 @@ class Session {
         if ($stop) {
             $stopField = "stop=now(),";
         }
+        $addAP = false;
+        $apText = "";
+        if (! empty($this->ap)) {
+            $addAP = true;
+            $apText = " and ap=:ap ";
+        }
         $db = DB::getInstance();
         $dbLink = $db->getConnection();
         $handle = $dbLink->prepare(
                 "update session set " . $stopField .
                     " inMB=:inMB, outMB=:outMB, building_identifier=:buildingID "
                 . "where siteIP=:siteIP and username=:username "
-                    . "and stop is null and mac=:mac "
+                    . "and stop is null and mac=:mac " . $apText
                     . "and start between :startmin and :startmax");
         // Some (300/11500) sessions are started multiple times in the same second, can
         // NOT use "order by start desc limit 1" here for now.
@@ -114,6 +120,9 @@ class Session {
         $handle->bindValue(':siteIP',     $this->siteIP,             PDO::PARAM_STR);
         $handle->bindValue(':username',   $this->login,              PDO::PARAM_STR);
         $handle->bindValue(':mac',        $this->mac,                PDO::PARAM_STR);
+        if ($addAP) {
+            $handle->bindValue(':ap',     $this->ap,                 PDO::PARAM_STR);
+        }
         $handle->bindValue(':inMB',       $this->inMB(),             PDO::PARAM_INT);
         $handle->bindValue(':outMB',      $this->outMB(),            PDO::PARAM_INT);
         $handle->bindValue(':buildingID', $this->buildingIdentifier, PDO::PARAM_STR);

--- a/src/Session.php
+++ b/src/Session.php
@@ -118,16 +118,20 @@ class Session {
         $handle->bindValue(':inMB',       $this->inMB(),             PDO::PARAM_INT);
         $handle->bindValue(':outMB',      $this->outMB(),            PDO::PARAM_INT);
         $handle->bindValue(':buildingID', $this->buildingIdentifier, PDO::PARAM_STR);
-        $success = false;
+        $affectedRows = 0;
         try {
-            $success = $handle->execute();
+            $dbLink->beginTransaction();
+            $handle->execute();
+            $affectedRows = $handle->rowCount();
+            $dbLink->commit();
         } catch (PDOException $e) {
+            $dbLink->rollBack();
             error_log("Exception while updating session: " .
                 $e->getMessage() . "|Trace: " . implode("|" . $e->getTrace()));
         }
-        if ($success) {
+        if ($affectedRows > 0) {
             error_log("Session record updated. " .
-                $startMin . " and " . $startMax . " for " . $this->login);
+                $startMin . " and " . $startMax . " for " . $this->login . " Rows: " . $affectedRows);
         } else {
             error_log("Session update failed. " .
                 $startMin . " and " . $startMax . " for " . $this->login);


### PR DESCRIPTION
- Only save session on start request if we have a building identifier to save. 
- Add AP to query conditions if we have an AP to add.
- Remove AP condition as it proved inconsistent in staging tests, add exception handling and custom success message so we can gauge the extent of failed updates without hitting the generic alarm.
- Add DB transaction around update query