### PR TITLE
Change stop event with no start event to 204

### DIFF
--- a/src/AAA.php
+++ b/src/AAA.php
@@ -266,6 +266,7 @@ class AAA {
                 } else {
                     error_log("No previous record found for accounting stop request. ID ["
                         . $this->session->id. "]");
+                    $this->responseHeader = self::HTTP_RESPONSE_NO_CONTENT;
                 }
                 break;
             case self::ACCOUNTING_TYPE_INTERIM:

--- a/tests/unit/AAATest.php
+++ b/tests/unit/AAATest.php
@@ -314,7 +314,7 @@ class AAATest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(
             [
                 'headers' => [
-                    TestConstants::HTTP_11_NOT_FOUND,
+                    TestConstants::HTTP_11_NO_DATA,
                     "Content-Type: application/json",
                 ],
                 'body' => ''


### PR DESCRIPTION
## What

In freeradius, responding with a 404 results in a spurious error message
in the free radius logs which is noisy - changing this to a 204 should
stop this error message occurring. Free radius expects the response to
be a 2xx or 5xx - this error is not a server error, so 204 is the most
appropriate response

## How te review

Code review, check tests pass

## Who can review

Anyone but me