### PR TITLE
Handle BEIS sponsor email problem when sent from outlook

### DIFF
--- a/tests/TestConstants.php
+++ b/tests/TestConstants.php
@@ -44,6 +44,8 @@ class TestConstants {
     const FIXTURE_EMAIL_SPONSOR_SIGNATURE = "tests/unit/fixtures/email-sponsor-signature.txt";
     const FIXTURE_EMAIL_SPONSOR_EMPTY     = "tests/unit/fixtures/email-sponsor-empty.txt";
     const FIXTURE_EMAIL_SPONSOR_CONCAT    = "tests/unit/fixtures/email-sponsor-autoconcat.txt";
+    const FIXTURE_EMAIL_SPONSOR_BASE64    = "tests/unit/fixtures/email-sponsor-base64.txt";
+    const FIXTURE_EMAIL_SPONSOR_BASE64_H  = "tests/unit/fixtures/email-sponsor-base64-htmlonly.txt";
     const FIXTURE_EMAIL_NEW_SITE_IP       = "tests/unit/fixtures/email-newsite-extraip.txt";
     const FIXTURE_EMAIL_NEW_SITE_MULTI    = "tests/unit/fixtures/email-newsite-multipart.txt";
     const TIMESTAMP_PLACEHOLDER           = "#TIMESTAMP#";

--- a/tests/unit/EmailRequestTest.php
+++ b/tests/unit/EmailRequestTest.php
@@ -80,6 +80,22 @@ class EmailRequestTest extends PHPUnit_Framework_TestCase {
             implode(",", $this->emailRequest->uniqueContactList()));
     }
 
+    function testContactListFromBase64EncodedEmail() {
+        $body = file_get_contents(TestConstants::FIXTURE_EMAIL_SPONSOR_BASE64) . "\n";
+        $this->emailRequest->setEmailBody($body);
+        $this->assertEquals(
+            implode(",", array(self::CONTACT_EMAIL, self::CONTACT_NUMBER)),
+            implode(",", $this->emailRequest->uniqueContactList()));
+    }
+
+    function testContactListFromBase64EncodedEmailHTMLOnly() {
+        $body = file_get_contents(TestConstants::FIXTURE_EMAIL_SPONSOR_BASE64_H) . "\n";
+        $this->emailRequest->setEmailBody($body);
+        $this->assertEquals(
+            implode(",", array(self::CONTACT_EMAIL, self::CONTACT_NUMBER)),
+            implode(",", $this->emailRequest->uniqueContactList()));
+    }
+
     function testNewSiteIpSelection() {
         $body = file_get_contents(TestConstants::FIXTURE_EMAIL_NEW_SITE_IP) . "\n";
         $this->emailRequest->setEmailBody($body);
@@ -102,4 +118,5 @@ class EmailRequestTest extends PHPUnit_Framework_TestCase {
             $this->emailRequest->ipList()
         );
     }
+
 }

--- a/tests/unit/fixtures/email-sponsor-base64-htmlonly.txt
+++ b/tests/unit/fixtures/email-sponsor-base64-htmlonly.txt
@@ -1,0 +1,74 @@
+Return-Path: <test.sponsor@test.domain.com>
+Received: from test.domain2.com (mail-ve1eur0test.domain3.com [1.1.1.1])
+ by inbound-smtp.test.domain4.com with SMTP id qtl9kqn2nk0elcq323v6oo27k10i4p8eb3ckito1
+ for sponsor@staging.wifi.server.com;
+ Fri, 17 Nov 2017 06:17:47 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of test.domain.com designates 1.1.1.1 as permitted sender) client-ip=1.1.1.1; envelope-from=test.sponsor@test.domain.com; helo=mail-ve1eur0test.domain3.com;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of test.domain.com designates 1.1.1.1 as permitted sender) client-ip=1.1.1.1; envelope-from=test.sponsor@test.domain.com; helo=mail-ve1eur0test.domain3.com;
+ dkim=pass header.i=@test.domain5.com;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFISHlKZ1dLbVFjS2hDV29yVE5nSG9xaHhpdHFxMk9WeE9JcXd6UzBUemZaWjFLbTR2eU82T1VMeFl6eXN2VFdETlFxZytCSVJVUDhaMzFNMG5raXBVRElKNitQM3Fob1F1aVBMVEtoc1JkQ0RpMjVEZ3hCcm54Q21XdDBPa1Y4Si9OVThnVXFUa1BJTlh6U0dZcTIrNVVPaG5DSDZhaXdwanJENmxXTm10VC9OdmFyWTB3OWdrUEFvc0dCVnZJZFU3cWxieUJIdkJhTmtXalRWazg0dnNXek4xVFVkSy9iNnBISlN2WlZTWkV1cjJDNS9EMFZ2ZkRoeGRabjA5THlXL05xUmFnUGdMOFV1elczbVZxc1hNc1FoMkRhdlI2YnA0aWIrWnNsMGM0cE8vS0p5WkhWbVdxU21rbms4RGowakE9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=U3qRsWQjWBOHud/eCVR1hpu4wRWQJsQ6Aqud29V6wgybXTdhwmMKjWo2wYyox1Dpp30bxQaPIFuoRoKUP8mF/DmEevtTqnZBcpsDtvMrheD0TkniQec3gRwErYTnuXnnw2NMBb27nfDcJWhVMGWLxTDkXgAovPrgj9LG9qozNbk=; c=relaxed/simple; s=shh3fegwg5fppqsuzphvschd53n6ihuv; d=amazonses.com; t=1510899468; v=1; bh=0KzkOESEkyH6VX5Tz/Ca9E+hPAPb0kKwGdgLde8fITA=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+ d=test.domain5.com; s=selector1-test-domain-1-com;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version;
+ bh=0KzkOESEkyH6VX5Tz/Ca9E+hPAPb0kKwGdgLde8fITA=;
+ b=Jdpvy8Vl2n55I9jkSLoSzU/E2OZtKcEfX9C/ei+yrnB5hl4MiLkSZBYxj43RgZsjQcWfRbQ2l2OM0O1klI9VieUbfou379yPTlofefmm92IFNiUeuzbii8G6JnvbClhCa894qQ9NlLBE4Trd93XZWXDF8s1LmAG/kOn2ahEOeWg=
+Received: from MM1P123MB1356.GBRP123.test.domain7.com (1.1.1.2) by
+ MM1P123MB1354.GBRP123.test.domain7.com (1.1.1.3) with Microsoft SMTP
+ Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256) id
+ 1.1.1.4; Fri, 17 Nov 2017 06:17:46 +0000
+Received: from MM1P123MB1356.GBRP123.test.domain7.com ([1.1.1.2]) by
+ MM1P123MB1356.GBRP123.test.domain7.com ([1.1.1.2]) with mapi id
+ 15.20.0239.005; Fri, 17 Nov 2017 06:17:46 +0000
+From: "Test, User (Sponsor)" <test.sponsor@test.domain.com>
+To: "sponsor@staging.wifi.server.com"
+	<sponsor@staging.wifi.server.com>
+Subject: <no subject>
+Thread-Topic: <no subject>
+Thread-Index: AQHTX2vJrTwycQa+7kS6UJ/kevoVOQ==
+Date: Fri, 17 Nov 2017 06:17:46 +0000
+Message-ID: <B48D00A1-8ED5-4543-ABE4-DBB141B15BBD@contoso.com>
+Accept-Language: en-GB, en-US
+Content-Language: en-US
+X-MS-Has-Attach:
+X-MS-TNEF-Correlator:
+authentication-results: spf=none (sender IP is )
+ smtp.mailfrom=test.sponsor@test.domain.com; 
+x-originating-ip: [1.1.1.7]
+x-ms-publictraffictype: Email
+x-microsoft-exchange-diagnostics: 1;MM1P123MB1354;6:k39YfRONQFiJD57JyPQh6ILcALmho8mWNCcEE9IFExBZWWJsRtemYESgvDXig3Vk2/MkVXR++1rHbNR77fuKpHBqYPzT4s0eKE9spNXKWP6cVks/C9Alm5RvG0ujSHj4v0UxXR0yF044PgeoUJEDZIhhbZs9bgY+GGO5sk9l36M1V9v+yBDIE5ARIzaQ+K+OCykZPN/NRHiEN/bSOnigMpOYXuxrFPfGzXJFy7iY0b3z6w3IwIg1i+cD49i/UGF+QmyvEshOA6+Az497PEp3sj7/xLQtvugTA7U4KcOVMQyurNc3XYGEd4XdmSWPaaAev9P6TvpaEJDFw7kg7DATYwUrNQf6P0DO62M2rlXN9io=;5:YIaI2wN9f6pIQFvHYySRSQ/VFtzFoZJ9esDoIu+CZy8mKgb//pCZPbS+pTosvXkFGQggxvMkqvD/xTPGTYO+6hc+IW4AlShTWsbXDOMzgmJcQ6B5WGl9w0MWyoECKPoijj3fpURCZ/e3trOIeqNASs2CxoQb8Ck1+tTipC7DYZY=;24:HeidJvJhcbOAwju/2HfzCYYT2N7SkpS4q1HHvaBy8w6G+Gpo7jq3oePKxv6UhTFjSsLDHbySHiuWWDzlPhljAMzgkEAqop42/4oANPg5/0A=;7:V65ZHX9Ucgtoz8K2AA4HP5P/N/WW+plLsUuTDfO9D3D/wWegnfVuvr47EDRyXxY81ovVxKCRk90owk+17TeKBvuve4TCalZWIlu1I98n/mkeO4Dc7pfev9uLfbqGWIyhBRmG+pX4FoFFZi+pe5AsImKnQoYUbH/BEq3UcuwYqJ7reC4R2JadO1eTlXUIMO6Z45Gy0ThG0YKe1bxyUzyIAbMYRKVOziHomiQXSCWKqfzytidopSPNWlzpBwCtzl2m
+x-ms-exchange-antispam-srfa-diagnostics: SSOS;
+x-ms-office365-filtering-correlation-id: 7eebda6a-f4e2-4e90-70e8-08d52d82ebb8
+x-microsoft-antispam: UriScan:;BCL:0;PCL:0;RULEID:(22001)(4534020)(4602075)(4603075)(7168020)(4627115)(201702281549075)(2017052603199);SRVR:MM1P123MB1354;
+x-ms-traffictypediagnostic: MM1P123MB1354:
+x-microsoft-antispam-prvs: <MM1P123MB13547F5079F7B665D5F18069832F0@MM1P123MB1354.GBRP123.test.domain7.com>
+x-exchange-antispam-report-test: UriScan:(227612066756510)(21748063052155);
+x-exchange-antispam-report-cfa-test: BCL:0;PCL:0;RULEID:(100000700101)(100105000095)(100000701101)(100105300095)(100000702101)(100105100095)(6040450)(2401047)(8121501046)(5005006)(10201501046)(100000703101)(100105400095)(93006095)(93001095)(3231022)(3002001)(6041248)(20161123564025)(20161123562025)(20161123560025)(20161123555025)(201703131423075)(201702281528075)(201703061421075)(201703061406153)(20161123558100)(2016111802025)(6043046)(6072148)(201708071742011)(100000704101)(100105200095)(100000705101)(100105500095);SRVR:MM1P123MB1354;BCL:0;PCL:0;RULEID:(100000800101)(100110000095)(100000801101)(100110300095)(100000802101)(100110100095)(100000803101)(100110400095)(100000804101)(100110200095)(100000805101)(100110500095);SRVR:MM1P123MB1354;
+x-forefront-prvs: 049486C505
+x-forefront-antispam-report: SFV:NSPM;SFS:(10009020)(6009001)(346002)(376002)(189002)(199003)(3660700001)(105586002)(3280700002)(6486002)(77096006)(6916009)(42882006)(4270600006)(2501003)(6506006)(97736004)(2906002)(83716003)(2351001)(8936002)(2900100001)(68736007)(5660300001)(106356001)(74482002)(33656002)(189998001)(14454004)(478600001)(9686003)(6512007)(6306002)(555874004)(551214005)(3846002)(102836003)(6116002)(558084003)(82746002)(86362001)(53936002)(7736002)(316002)(75922002)(101416001)(81166006)(8676002)(81156014)(1730700003)(99286004)(25786009)(36756003)(55236003)(5640700003)(54896002)(66066001)(6436002)(588024002)(50986999)(54356999)(478044003);DIR:OUT;SFP:1101;SCL:1;SRVR:MM1P123MB1354;H:MM1P123MB1356.GBRP123.test.domain7.com;FPR:;SPF:None;PTR:InfoNoRecords;MX:1;A:0;LANG:en;
+received-spf: None (protection.outlook.com: test.domain.com does not
+ designate permitted sender hosts)
+spamdiagnosticoutput: 1:99
+spamdiagnosticmetadata: NSPM
+Content-Type: multipart/alternative;
+	boundary="_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_"
+MIME-Version: 1.0
+X-OriginatorOrg: test.domain.com
+X-MS-Exchange-CrossTenant-Network-Message-Id: 7eebda6a-f4e2-4e90-70e8-08d52d82ebb8
+X-MS-Exchange-CrossTenant-originalarrivaltime: 17 Nov 2017 06:17:46.5431
+ (UTC)
+X-MS-Exchange-CrossTenant-fromentityheader: Hosted
+X-MS-Exchange-CrossTenant-id: cbac7005-02c1-43eb-b497-e6492d1b2dd8
+X-MS-Exchange-Transport-CrossTenantHeadersStamped: MM1P123MB1354
+
+--_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_
+Content-Type: text/html; charset="utf-8"
+Content-ID: <953670F16F237B40B6D034EF4D05012F@GBRP123.test.domain7.com>
+Content-Transfer-Encoding: base64
+
+PGh0bWwgeG1sbnM6bz0idXJuOnNjaGVtYXMtbWljcm9zb2Z0LWNvbTpvZmZpY2U6b2ZmaWNlIiB4bWxuczp3PSJ1cm46c2NoZW1hcy1taWNyb3NvZnQtY29tOm9mZmljZTp3b3JkIiB4bWxuczptPSJodHRwOi8vc2NoZW1hcy5taWNyb3NvZnQuY29tL29mZmljZS8yMDA0LzEyL29tbWwiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy9UUi9SRUMtaHRtbDQwIj4KPGhlYWQ+CjxtZXRhIGh0dHAtZXF1aXY9IkNvbnRlbnQtVHlwZSIgY29udGVudD0idGV4dC9odG1sOyBjaGFyc2V0PXV0Zi04Ij4KPG1ldGEgbmFtZT0iVGl0bGUiIGNvbnRlbnQ9IiI+CjxtZXRhIG5hbWU9IktleXdvcmRzIiBjb250ZW50PSIiPgo8bWV0YSBuYW1lPSJHZW5lcmF0b3IiIGNvbnRlbnQ9Ik1pY3Jvc29mdCBXb3JkIDE1IChmaWx0ZXJlZCBtZWRpdW0pIj4KPHN0eWxlPjwhLS0KLyogRm9udCBEZWZpbml0aW9ucyAqLwpAZm9udC1mYWNlCgl7Zm9udC1mYW1pbHk6IkNhbWJyaWEgTWF0aCI7CglwYW5vc2UtMToyIDQgNSAzIDUgNCA2IDMgMiA0O30KQGZvbnQtZmFjZQoJe2ZvbnQtZmFtaWx5OkNhbGlicmk7CglwYW5vc2UtMToyIDE1IDUgMiAyIDIgNCAzIDIgNDt9Ci8qIFN0eWxlIERlZmluaXRpb25zICovCnAuTXNvTm9ybWFsLCBsaS5Nc29Ob3JtYWwsIGRpdi5Nc29Ob3JtYWwKCXttYXJnaW46MGluOwoJbWFyZ2luLWJvdHRvbTouMDAwMXB0OwoJZm9udC1zaXplOjEyLjBwdDsKCWZvbnQtZmFtaWx5OiJDYWxpYnJpIixzYW5zLXNlcmlmO30KYTpsaW5rLCBzcGFuLk1zb0h5cGVybGluawoJe21zby1zdHlsZS1wcmlvcml0eTo5OTsKCWNvbG9yOiMwNTYzQzE7Cgl0ZXh0LWRlY29yYXRpb246dW5kZXJsaW5lO30KYTp2aXNpdGVkLCBzcGFuLk1zb0h5cGVybGlua0ZvbGxvd2VkCgl7bXNvLXN0eWxlLXByaW9yaXR5Ojk5OwoJY29sb3I6Izk1NEY3MjsKCXRleHQtZGVjb3JhdGlvbjp1bmRlcmxpbmU7fQpzcGFuLkVtYWlsU3R5bGUxNwoJe21zby1zdHlsZS10eXBlOnBlcnNvbmFsLWNvbXBvc2U7Cglmb250LWZhbWlseToiQ2FsaWJyaSIsc2Fucy1zZXJpZjsKCWNvbG9yOndpbmRvd3RleHQ7fQpzcGFuLm1zb0lucwoJe21zby1zdHlsZS10eXBlOmV4cG9ydC1vbmx5OwoJbXNvLXN0eWxlLW5hbWU6IiI7Cgl0ZXh0LWRlY29yYXRpb246dW5kZXJsaW5lOwoJY29sb3I6dGVhbDt9Ci5Nc29DaHBEZWZhdWx0Cgl7bXNvLXN0eWxlLXR5cGU6ZXhwb3J0LW9ubHk7Cglmb250LWZhbWlseToiQ2FsaWJyaSIsc2Fucy1zZXJpZjt9CkBwYWdlIFdvcmRTZWN0aW9uMQoJe3NpemU6NTk1LjBwdCA4NDIuMHB0OwoJbWFyZ2luOjEuMGluIDEuMGluIDEuMGluIDEuMGluO30KZGl2LldvcmRTZWN0aW9uMQoJe3BhZ2U6V29yZFNlY3Rpb24xO30KLS0+PC9zdHlsZT4KPC9oZWFkPgo8Ym9keSBiZ2NvbG9yPSJ3aGl0ZSIgbGFuZz0iRU4tVVMiIGxpbms9IiMwNTYzQzEiIHZsaW5rPSIjOTU0RjcyIj4KPGRpdiBjbGFzcz0iV29yZFNlY3Rpb24xIj4KPHAgY2xhc3M9Ik1zb05vcm1hbCI+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij5leGFtcGxlLnVzZXIyQGV4YW1wbGUuY28udWs8L3NwYW4+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij48bzpwPjwvbzpwPjwvc3Bhbj48L3A+CjxwIGNsYXNzPSJNc29Ob3JtYWwiPjxzcGFuIGxhbmc9IkVOLUdCIiBzdHlsZT0iZm9udC1zaXplOjExLjBwdCI+MDcxMjM0NTY3ODk8L3NwYW4+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij48bzpwPjwvbzpwPjwvc3Bhbj48L3A+CjwvZGl2Pgo8L2JvZHk+CjwvaHRtbD4K
+
+--_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_--

--- a/tests/unit/fixtures/email-sponsor-base64.txt
+++ b/tests/unit/fixtures/email-sponsor-base64.txt
@@ -1,0 +1,80 @@
+Return-Path: <test.sponsor@test.domain.com>
+Received: from test.domain2.com (mail-ve1eur0test.domain3.com [1.1.1.1])
+ by inbound-smtp.test.domain4.com with SMTP id qtl9kqn2nk0elcq323v6oo27k10i4p8eb3ckito1
+ for sponsor@staging.wifi.server.com;
+ Fri, 17 Nov 2017 06:17:47 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of test.domain.com designates 1.1.1.1 as permitted sender) client-ip=1.1.1.1; envelope-from=test.sponsor@test.domain.com; helo=mail-ve1eur0test.domain3.com;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of test.domain.com designates 1.1.1.1 as permitted sender) client-ip=1.1.1.1; envelope-from=test.sponsor@test.domain.com; helo=mail-ve1eur0test.domain3.com;
+ dkim=pass header.i=@test.domain5.com;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFISHlKZ1dLbVFjS2hDV29yVE5nSG9xaHhpdHFxMk9WeE9JcXd6UzBUemZaWjFLbTR2eU82T1VMeFl6eXN2VFdETlFxZytCSVJVUDhaMzFNMG5raXBVRElKNitQM3Fob1F1aVBMVEtoc1JkQ0RpMjVEZ3hCcm54Q21XdDBPa1Y4Si9OVThnVXFUa1BJTlh6U0dZcTIrNVVPaG5DSDZhaXdwanJENmxXTm10VC9OdmFyWTB3OWdrUEFvc0dCVnZJZFU3cWxieUJIdkJhTmtXalRWazg0dnNXek4xVFVkSy9iNnBISlN2WlZTWkV1cjJDNS9EMFZ2ZkRoeGRabjA5THlXL05xUmFnUGdMOFV1elczbVZxc1hNc1FoMkRhdlI2YnA0aWIrWnNsMGM0cE8vS0p5WkhWbVdxU21rbms4RGowakE9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=U3qRsWQjWBOHud/eCVR1hpu4wRWQJsQ6Aqud29V6wgybXTdhwmMKjWo2wYyox1Dpp30bxQaPIFuoRoKUP8mF/DmEevtTqnZBcpsDtvMrheD0TkniQec3gRwErYTnuXnnw2NMBb27nfDcJWhVMGWLxTDkXgAovPrgj9LG9qozNbk=; c=relaxed/simple; s=shh3fegwg5fppqsuzphvschd53n6ihuv; d=amazonses.com; t=1510899468; v=1; bh=0KzkOESEkyH6VX5Tz/Ca9E+hPAPb0kKwGdgLde8fITA=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+ d=test.domain5.com; s=selector1-test-domain-1-com;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version;
+ bh=0KzkOESEkyH6VX5Tz/Ca9E+hPAPb0kKwGdgLde8fITA=;
+ b=Jdpvy8Vl2n55I9jkSLoSzU/E2OZtKcEfX9C/ei+yrnB5hl4MiLkSZBYxj43RgZsjQcWfRbQ2l2OM0O1klI9VieUbfou379yPTlofefmm92IFNiUeuzbii8G6JnvbClhCa894qQ9NlLBE4Trd93XZWXDF8s1LmAG/kOn2ahEOeWg=
+Received: from MM1P123MB1356.GBRP123.test.domain7.com (1.1.1.2) by
+ MM1P123MB1354.GBRP123.test.domain7.com (1.1.1.3) with Microsoft SMTP
+ Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256) id
+ 1.1.1.4; Fri, 17 Nov 2017 06:17:46 +0000
+Received: from MM1P123MB1356.GBRP123.test.domain7.com ([1.1.1.2]) by
+ MM1P123MB1356.GBRP123.test.domain7.com ([1.1.1.2]) with mapi id
+ 15.20.0239.005; Fri, 17 Nov 2017 06:17:46 +0000
+From: "Test, User (Sponsor)" <test.sponsor@test.domain.com>
+To: "sponsor@staging.wifi.server.com"
+	<sponsor@staging.wifi.server.com>
+Subject: <no subject>
+Thread-Topic: <no subject>
+Thread-Index: AQHTX2vJrTwycQa+7kS6UJ/kevoVOQ==
+Date: Fri, 17 Nov 2017 06:17:46 +0000
+Message-ID: <B48D00A1-8ED5-4543-ABE4-DBB141B15BBD@contoso.com>
+Accept-Language: en-GB, en-US
+Content-Language: en-US
+X-MS-Has-Attach:
+X-MS-TNEF-Correlator:
+authentication-results: spf=none (sender IP is )
+ smtp.mailfrom=test.sponsor@test.domain.com; 
+x-originating-ip: [1.1.1.7]
+x-ms-publictraffictype: Email
+x-microsoft-exchange-diagnostics: 1;MM1P123MB1354;6:k39YfRONQFiJD57JyPQh6ILcALmho8mWNCcEE9IFExBZWWJsRtemYESgvDXig3Vk2/MkVXR++1rHbNR77fuKpHBqYPzT4s0eKE9spNXKWP6cVks/C9Alm5RvG0ujSHj4v0UxXR0yF044PgeoUJEDZIhhbZs9bgY+GGO5sk9l36M1V9v+yBDIE5ARIzaQ+K+OCykZPN/NRHiEN/bSOnigMpOYXuxrFPfGzXJFy7iY0b3z6w3IwIg1i+cD49i/UGF+QmyvEshOA6+Az497PEp3sj7/xLQtvugTA7U4KcOVMQyurNc3XYGEd4XdmSWPaaAev9P6TvpaEJDFw7kg7DATYwUrNQf6P0DO62M2rlXN9io=;5:YIaI2wN9f6pIQFvHYySRSQ/VFtzFoZJ9esDoIu+CZy8mKgb//pCZPbS+pTosvXkFGQggxvMkqvD/xTPGTYO+6hc+IW4AlShTWsbXDOMzgmJcQ6B5WGl9w0MWyoECKPoijj3fpURCZ/e3trOIeqNASs2CxoQb8Ck1+tTipC7DYZY=;24:HeidJvJhcbOAwju/2HfzCYYT2N7SkpS4q1HHvaBy8w6G+Gpo7jq3oePKxv6UhTFjSsLDHbySHiuWWDzlPhljAMzgkEAqop42/4oANPg5/0A=;7:V65ZHX9Ucgtoz8K2AA4HP5P/N/WW+plLsUuTDfO9D3D/wWegnfVuvr47EDRyXxY81ovVxKCRk90owk+17TeKBvuve4TCalZWIlu1I98n/mkeO4Dc7pfev9uLfbqGWIyhBRmG+pX4FoFFZi+pe5AsImKnQoYUbH/BEq3UcuwYqJ7reC4R2JadO1eTlXUIMO6Z45Gy0ThG0YKe1bxyUzyIAbMYRKVOziHomiQXSCWKqfzytidopSPNWlzpBwCtzl2m
+x-ms-exchange-antispam-srfa-diagnostics: SSOS;
+x-ms-office365-filtering-correlation-id: 7eebda6a-f4e2-4e90-70e8-08d52d82ebb8
+x-microsoft-antispam: UriScan:;BCL:0;PCL:0;RULEID:(22001)(4534020)(4602075)(4603075)(7168020)(4627115)(201702281549075)(2017052603199);SRVR:MM1P123MB1354;
+x-ms-traffictypediagnostic: MM1P123MB1354:
+x-microsoft-antispam-prvs: <MM1P123MB13547F5079F7B665D5F18069832F0@MM1P123MB1354.GBRP123.test.domain7.com>
+x-exchange-antispam-report-test: UriScan:(227612066756510)(21748063052155);
+x-exchange-antispam-report-cfa-test: BCL:0;PCL:0;RULEID:(100000700101)(100105000095)(100000701101)(100105300095)(100000702101)(100105100095)(6040450)(2401047)(8121501046)(5005006)(10201501046)(100000703101)(100105400095)(93006095)(93001095)(3231022)(3002001)(6041248)(20161123564025)(20161123562025)(20161123560025)(20161123555025)(201703131423075)(201702281528075)(201703061421075)(201703061406153)(20161123558100)(2016111802025)(6043046)(6072148)(201708071742011)(100000704101)(100105200095)(100000705101)(100105500095);SRVR:MM1P123MB1354;BCL:0;PCL:0;RULEID:(100000800101)(100110000095)(100000801101)(100110300095)(100000802101)(100110100095)(100000803101)(100110400095)(100000804101)(100110200095)(100000805101)(100110500095);SRVR:MM1P123MB1354;
+x-forefront-prvs: 049486C505
+x-forefront-antispam-report: SFV:NSPM;SFS:(10009020)(6009001)(346002)(376002)(189002)(199003)(3660700001)(105586002)(3280700002)(6486002)(77096006)(6916009)(42882006)(4270600006)(2501003)(6506006)(97736004)(2906002)(83716003)(2351001)(8936002)(2900100001)(68736007)(5660300001)(106356001)(74482002)(33656002)(189998001)(14454004)(478600001)(9686003)(6512007)(6306002)(555874004)(551214005)(3846002)(102836003)(6116002)(558084003)(82746002)(86362001)(53936002)(7736002)(316002)(75922002)(101416001)(81166006)(8676002)(81156014)(1730700003)(99286004)(25786009)(36756003)(55236003)(5640700003)(54896002)(66066001)(6436002)(588024002)(50986999)(54356999)(478044003);DIR:OUT;SFP:1101;SCL:1;SRVR:MM1P123MB1354;H:MM1P123MB1356.GBRP123.test.domain7.com;FPR:;SPF:None;PTR:InfoNoRecords;MX:1;A:0;LANG:en;
+received-spf: None (protection.outlook.com: test.domain.com does not
+ designate permitted sender hosts)
+spamdiagnosticoutput: 1:99
+spamdiagnosticmetadata: NSPM
+Content-Type: multipart/alternative;
+	boundary="_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_"
+MIME-Version: 1.0
+X-OriginatorOrg: test.domain.com
+X-MS-Exchange-CrossTenant-Network-Message-Id: 7eebda6a-f4e2-4e90-70e8-08d52d82ebb8
+X-MS-Exchange-CrossTenant-originalarrivaltime: 17 Nov 2017 06:17:46.5431
+ (UTC)
+X-MS-Exchange-CrossTenant-fromentityheader: Hosted
+X-MS-Exchange-CrossTenant-id: cbac7005-02c1-43eb-b497-e6492d1b2dd8
+X-MS-Exchange-Transport-CrossTenantHeadersStamped: MM1P123MB1354
+
+--_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: base64
+
+ZXhhbXBsZS51c2VyMkBleGFtcGxlLmNvLnVrCjA3MTIzNDU2Nzg5
+
+--_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_
+Content-Type: text/html; charset="utf-8"
+Content-ID: <953670F16F237B40B6D034EF4D05012F@GBRP123.test.domain7.com>
+Content-Transfer-Encoding: base64
+
+PGh0bWwgeG1sbnM6bz0idXJuOnNjaGVtYXMtbWljcm9zb2Z0LWNvbTpvZmZpY2U6b2ZmaWNlIiB4bWxuczp3PSJ1cm46c2NoZW1hcy1taWNyb3NvZnQtY29tOm9mZmljZTp3b3JkIiB4bWxuczptPSJodHRwOi8vc2NoZW1hcy5taWNyb3NvZnQuY29tL29mZmljZS8yMDA0LzEyL29tbWwiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy9UUi9SRUMtaHRtbDQwIj4KPGhlYWQ+CjxtZXRhIGh0dHAtZXF1aXY9IkNvbnRlbnQtVHlwZSIgY29udGVudD0idGV4dC9odG1sOyBjaGFyc2V0PXV0Zi04Ij4KPG1ldGEgbmFtZT0iVGl0bGUiIGNvbnRlbnQ9IiI+CjxtZXRhIG5hbWU9IktleXdvcmRzIiBjb250ZW50PSIiPgo8bWV0YSBuYW1lPSJHZW5lcmF0b3IiIGNvbnRlbnQ9Ik1pY3Jvc29mdCBXb3JkIDE1IChmaWx0ZXJlZCBtZWRpdW0pIj4KPHN0eWxlPjwhLS0KLyogRm9udCBEZWZpbml0aW9ucyAqLwpAZm9udC1mYWNlCgl7Zm9udC1mYW1pbHk6IkNhbWJyaWEgTWF0aCI7CglwYW5vc2UtMToyIDQgNSAzIDUgNCA2IDMgMiA0O30KQGZvbnQtZmFjZQoJe2ZvbnQtZmFtaWx5OkNhbGlicmk7CglwYW5vc2UtMToyIDE1IDUgMiAyIDIgNCAzIDIgNDt9Ci8qIFN0eWxlIERlZmluaXRpb25zICovCnAuTXNvTm9ybWFsLCBsaS5Nc29Ob3JtYWwsIGRpdi5Nc29Ob3JtYWwKCXttYXJnaW46MGluOwoJbWFyZ2luLWJvdHRvbTouMDAwMXB0OwoJZm9udC1zaXplOjEyLjBwdDsKCWZvbnQtZmFtaWx5OiJDYWxpYnJpIixzYW5zLXNlcmlmO30KYTpsaW5rLCBzcGFuLk1zb0h5cGVybGluawoJe21zby1zdHlsZS1wcmlvcml0eTo5OTsKCWNvbG9yOiMwNTYzQzE7Cgl0ZXh0LWRlY29yYXRpb246dW5kZXJsaW5lO30KYTp2aXNpdGVkLCBzcGFuLk1zb0h5cGVybGlua0ZvbGxvd2VkCgl7bXNvLXN0eWxlLXByaW9yaXR5Ojk5OwoJY29sb3I6Izk1NEY3MjsKCXRleHQtZGVjb3JhdGlvbjp1bmRlcmxpbmU7fQpzcGFuLkVtYWlsU3R5bGUxNwoJe21zby1zdHlsZS10eXBlOnBlcnNvbmFsLWNvbXBvc2U7Cglmb250LWZhbWlseToiQ2FsaWJyaSIsc2Fucy1zZXJpZjsKCWNvbG9yOndpbmRvd3RleHQ7fQpzcGFuLm1zb0lucwoJe21zby1zdHlsZS10eXBlOmV4cG9ydC1vbmx5OwoJbXNvLXN0eWxlLW5hbWU6IiI7Cgl0ZXh0LWRlY29yYXRpb246dW5kZXJsaW5lOwoJY29sb3I6dGVhbDt9Ci5Nc29DaHBEZWZhdWx0Cgl7bXNvLXN0eWxlLXR5cGU6ZXhwb3J0LW9ubHk7Cglmb250LWZhbWlseToiQ2FsaWJyaSIsc2Fucy1zZXJpZjt9CkBwYWdlIFdvcmRTZWN0aW9uMQoJe3NpemU6NTk1LjBwdCA4NDIuMHB0OwoJbWFyZ2luOjEuMGluIDEuMGluIDEuMGluIDEuMGluO30KZGl2LldvcmRTZWN0aW9uMQoJe3BhZ2U6V29yZFNlY3Rpb24xO30KLS0+PC9zdHlsZT4KPC9oZWFkPgo8Ym9keSBiZ2NvbG9yPSJ3aGl0ZSIgbGFuZz0iRU4tVVMiIGxpbms9IiMwNTYzQzEiIHZsaW5rPSIjOTU0RjcyIj4KPGRpdiBjbGFzcz0iV29yZFNlY3Rpb24xIj4KPHAgY2xhc3M9Ik1zb05vcm1hbCI+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij5leGFtcGxlLnVzZXIyQGV4YW1wbGUuY28udWs8L3NwYW4+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij48bzpwPjwvbzpwPjwvc3Bhbj48L3A+CjxwIGNsYXNzPSJNc29Ob3JtYWwiPjxzcGFuIGxhbmc9IkVOLUdCIiBzdHlsZT0iZm9udC1zaXplOjExLjBwdCI+MDcxMjM0NTY3ODk8L3NwYW4+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij48bzpwPjwvbzpwPjwvc3Bhbj48L3A+CjwvZGl2Pgo8L2JvZHk+CjwvaHRtbD4K
+
+--_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_--


### PR DESCRIPTION
Add base64 decode for email body parsing where the appropriate Content-Transfer-Encoding is set. Make sure that the encoded string does not get mangled by turning the body to lowercase at the start.