### PR TITLE
Remove early site initialisation in order to reduce the number of queries against the database.

### DIFF
--- a/src/AAA.php
+++ b/src/AAA.php
@@ -134,7 +134,6 @@ class AAA {
                 case self::URL_SITE:
                     $this->siteIP = $parts[$x + 1];
                     $this->site = new Site;
-                    $this->site->loadByIp($this->siteIP);
                     break;
                 case self::URL_RESULT:
                     $this->result = $parts[$x + 1];


### PR DESCRIPTION
We've had a few alarms firing today caused by a significant traffic spike opening up several hundred database connections per minute as opposed to the 4-5 average.
This caused accounting updates to throttle. 

This change will remove the unnecessary early initialisation of the Site class for every incoming request.