### PR TITLE
Performance optimisations

### DIFF
--- a/src/AAA.php
+++ b/src/AAA.php
@@ -133,7 +133,6 @@ class AAA {
                     break;
                 case self::URL_SITE:
                     $this->siteIP = $parts[$x + 1];
-                    $this->site = new Site;
                     break;
                 case self::URL_RESULT:
                     $this->result = $parts[$x + 1];
@@ -301,8 +300,7 @@ class AAA {
             if ($this->user->login != "HEALTH") {
                 // insert a new entry into session (unless it's a health check)
                 $db = DB::getInstance();
-                $dbLink = $db->getConnection();
-                $handle = $dbLink->prepare(
+                $handle = $db->getConnection()->prepare(
                         'insert into session ' .
                         '(start, siteIP, username, mac, ap, building_identifier) ' .
                         'values (now(), :siteIP, :username, :mac, :ap, :building_identifier)');

--- a/src/DB.php
+++ b/src/DB.php
@@ -48,20 +48,7 @@ class DB {
      * @param int $dbType The type of the database connection, expected to be one of the allowed types.
      */
     private function __construct($dbType) {
-        try {
-            $this->setCredentials($dbType);
-            $this->connection = new PDO(
-                    'mysql:host=' . $this->hostname
-                    . '; dbname=' . $this->dbName
-                    . '; charset=utf8mb4',
-                    $this->username,
-                    $this->password,
-                    array(
-                        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                        PDO::ATTR_PERSISTENT => false));
-        } catch (PDOException $e) {
-            error_log($e->getMessage());
-        }
+        $this->setCredentials($dbType);
     }
 
     /**
@@ -97,6 +84,21 @@ class DB {
      * @return PDO The current database connection object.
      */
     public function getConnection() {
+        if (empty($this->connection)) {
+            try {
+                $this->connection = new PDO(
+                    'mysql:host=' . $this->hostname
+                    . '; dbname=' . $this->dbName
+                    . '; charset=utf8mb4',
+                    $this->username,
+                    $this->password,
+                    array(
+                        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                        PDO::ATTR_PERSISTENT => false));
+            } catch (PDOException $e) {
+                error_log($e->getMessage());
+            }
+        }
         return $this->connection;
     }
 }

--- a/src/OrgAdmin.php
+++ b/src/OrgAdmin.php
@@ -14,10 +14,9 @@ class OrgAdmin {
 
     public function __construct($email) {
         $db = DB::getInstance();
-        $dbLink = $db->getConnection();
-        
+
         $this->email = $email;
-        $handle = $dbLink->prepare(
+        $handle = $db->getConnection()->prepare(
                 'select id, mobile, orgname, name, email_manager_address from orgs_admins_view ' .
                 'where email=?');
         $handle->bindValue(1, $this->email, PDO::PARAM_STR);

--- a/src/User.php
+++ b/src/User.php
@@ -6,6 +6,7 @@ use PDO;
 
 class User {
     const RANDOM_BYTES_LENGTH_MULTIPLIER = 4;
+    const VALID_USERNAME_REGEX = "/[a-zA-Z]{5,6}/";
     /**
      * @var Identifier
      */
@@ -131,7 +132,7 @@ class User {
         $db = DB::getInstance();
         $userRecord = false;
 
-        if ($this->login) {
+        if (!empty($this->login) && preg_match(self::VALID_USERNAME_REGEX, $this->login)) {
             error_log("Loading user record for login: " . $this->login);
             $userRecord = $this->cache->get($this->login);
 

--- a/src/User.php
+++ b/src/User.php
@@ -6,7 +6,7 @@ use PDO;
 
 class User {
     const RANDOM_BYTES_LENGTH_MULTIPLIER = 4;
-    const VALID_USERNAME_REGEX = "/[a-zA-Z]{5,6}/";
+    const VALID_USERNAME_REGEX = "/^[a-zA-Z]{5,6}$/";
     /**
      * @var Identifier
      */
@@ -174,7 +174,7 @@ class User {
             } else if (isset($this->identifier)) {
                 error_log("User record not found for contact [" . $this->identifier->text . "]");
             } else {
-                error_log("User record not found.");
+                error_log("User record not found. Empty user details.");
             }
         }
     }

--- a/src/User.php
+++ b/src/User.php
@@ -89,10 +89,9 @@ class User {
 
     private function radiusDbWrite() {
         $db = DB::getInstance();
-        $dbLink = $db->getConnection();
 
         // Insert user record
-        $handle = $dbLink->prepare(
+        $handle = $db->getConnection()->prepare(
                 'insert into userdetails (username, contact, sponsor, password, email) '
                 . 'VALUES (:login, :contact, :sponsor, :password, :email) '
                 . 'ON DUPLICATE KEY UPDATE email=:email, password=:password');
@@ -130,7 +129,6 @@ class User {
      */
     public function loadRecord($force = false) {
         $db = DB::getInstance();
-        $dblink = $db->getConnection();
         $userRecord = false;
 
         if ($this->login) {
@@ -138,7 +136,7 @@ class User {
             $userRecord = $this->cache->get($this->login);
 
             if (! $userRecord) {
-                $handle = $dblink->prepare(
+                $handle = $db->getConnection()->prepare(
                         'select * from userdetails where username=?');
                 $handle->bindValue(1, $this->login, PDO::PARAM_STR);
                 $handle->execute();
@@ -151,7 +149,7 @@ class User {
             }
         } else if (isset($this->identifier) && $this->identifier->validMobile) {
             error_log("Loading user record for mobile: " . $this->identifier->text);
-            $handle = $dblink->prepare(
+            $handle = $db->getConnection()->prepare(
                     'select * from userdetails where contact=?');
             $handle->bindValue(1, $this->identifier->text, PDO::PARAM_STR);
             $handle->execute();
@@ -182,8 +180,8 @@ class User {
 
     private function usernameIsUnique($uname) {
         $db = DB::getInstance();
-        $dblink = $db->getConnection();
-        $handle = $dblink->prepare('select count(username) as unamecount '
+
+        $handle = $db->getConnection()->prepare('select count(username) as unamecount '
                 . 'from userdetails where username=?');
         $handle->bindValue(1, $uname, PDO::PARAM_STR);
         $handle->execute();
@@ -197,8 +195,8 @@ class User {
 
     private function setUsername() {
         $db = DB::getInstance();
-        $dblink = $db->getConnection();
-        $handle = $dblink->prepare('select distinct username '
+
+        $handle = $db->getConnection()->prepare('select distinct username '
                 . 'from userdetails where contact=?');
         $handle->bindValue(1, $this->identifier->text, PDO::PARAM_STR);
         $handle->execute();

--- a/tests/unit/AAATest.php
+++ b/tests/unit/AAATest.php
@@ -53,7 +53,6 @@ class AAATest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(Config::HEALTH_CHECK_USER, $aaa->user->login);
         $this->assertEquals("02-00-00-00-00-01",       $aaa->getMac());
         $this->assertEquals("02-00-00-42-00-01",       $aaa->getAp());
-        $this->assertInstanceOf(Site::class,           $aaa->site);
     }
 
     function testPostAuthAcceptUrlIsParsedProperly() {
@@ -63,7 +62,6 @@ class AAATest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(Config::HEALTH_CHECK_USER, $aaa->user->login);
         $this->assertEquals("02-00-00-00-00-01",       $aaa->getMac());
         $this->assertEquals("02-00-00-42-00-01",       $aaa->getAp());
-        $this->assertInstanceOf(Site::class,           $aaa->site);
         $this->assertEquals("Access-Accept",           $aaa->result);
     }
 
@@ -74,7 +72,6 @@ class AAATest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(Config::HEALTH_CHECK_USER, $aaa->user->login);
         $this->assertEquals("02-00-00-00-00-01",       $aaa->getMac());
         $this->assertEquals("02-00-00-42-00-01",       $aaa->getAp());
-        $this->assertInstanceOf(Site::class,           $aaa->site);
         $this->assertEquals("Access-Reject",           $aaa->result);
     }
 
@@ -92,7 +89,6 @@ class AAATest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(
             TestConstants::BUILDING_ID,
             $aaa->getBuildingIdentifier());
-        $this->assertInstanceOf(Site::class,           $aaa->site);
     }
 
     function testProcessAuthorisationRequestHealthCheck() {


### PR DESCRIPTION
Make DB connection lazy.

Most of our authorisation requests are served from cache - in these cases explicit database connection is not required. This change makes sure that a database connection is only created when one is requested, as opposed to at instanitation of the DB class.

Remove superfluous creation of a Site instance. Also make sure that a database connection is only requested when it is actually used.

Make sure the username is in the right format before trying to look it up in the DB. Restrict valid username regex further, improve log message for empty user details.