### PR TITLE
Use gethostbyname to get IP address instead of grepping /etc/hosts

### DIFF
--- a/tests/acceptance/RadiusServerTest.php
+++ b/tests/acceptance/RadiusServerTest.php
@@ -24,7 +24,7 @@ class RadiusServerTest extends PHPUnit_Framework_TestCase {
         );
         file_put_contents(self::CONFIG_FILE, $configuration);
 
-        $this->assertEquals(self::SUCCESS_LINE, exec("/bin/bash " . self::EAPOL_TEST_RUNNER));
+        $this->assertEquals(self::SUCCESS_LINE, $this->runEAPOverLanTest());
     }
 
     /**
@@ -39,7 +39,7 @@ class RadiusServerTest extends PHPUnit_Framework_TestCase {
         );
         file_put_contents(self::CONFIG_FILE, $configuration);
 
-        $this->assertEquals(self::SUCCESS_LINE, exec("/bin/bash " . self::EAPOL_TEST_RUNNER));
+        $this->assertEquals(self::SUCCESS_LINE, $this->runEAPOverLanTest());
     }
 
     /**
@@ -49,5 +49,23 @@ class RadiusServerTest extends PHPUnit_Framework_TestCase {
         @file_get_contents(TestConstants::REQUEST_PROTOCOL
             . TestConstants::getInstance()->getFrontendContainer() . "/");
         $this->assertEquals(TestConstants::HTTP_OK, $http_response_header[0]);
+    }
+
+    /**
+     * @return string
+     */
+    private function runEAPOverLanTest()
+    {
+        \putenv("FRONTEND_CONTAINER_IP={$this->frontendContainerIp()}");
+        return \exec("/bin/bash " . self::EAPOL_TEST_RUNNER);
+    }
+
+    /**
+     * @return string
+     */
+    private function frontendContainerIp()
+    {
+        $containerName = \getenv('FRONTEND_CONTAINER');
+        return \gethostbyname($containerName);
     }
 }

--- a/tests/acceptance/config/run-eapol-test.sh
+++ b/tests/acceptance/config/run-eapol-test.sh
@@ -4,7 +4,7 @@ eapol_test \
   -r1 \
   -t5 \
   -c $TEST_DIR/config/currentconfig.conf \
-  -a `cat /etc/hosts | grep -m 1 $FRONTEND_CONTAINER | awk '{ print $1 }'` \
+  -a $FRONTEND_CONTAINER_IP \
   -s $RADIUS_KEY \
   > $TEST_DIR/testresults.txt
 # TODO: maybe connect up a directory in the host machine with the container to retain


### PR DESCRIPTION
eapol_test requires an IPv4 address passed into it, but we only have the container name.

Previously we were performing the address lookup by inspecting the /etc/hosts file. This falls over when using docker-compose to manage the containers as it uses a DNS server.

PHPs gethostbyname will look at both /etc/hosts and DNS