### PR TITLE
Set the last_login field for a user on an accepted postauth request

### DIFF
--- a/src/AAA.php
+++ b/src/AAA.php
@@ -316,12 +316,22 @@ class AAA {
                     ':building_identifier', $this->buildingIdentifier, PDO::PARAM_STR);
 
                 $handle->execute();
+
+                $this->updateUserLastLogin();
             }
         } else if (self::AUTH_RESULT_REJECT == $this->result) {
             $this->responseHeader = self::HTTP_RESPONSE_NO_CONTENT;
         } else {
             $this->responseHeader = self::HTTP_RESPONSE_NOT_FOUND;
         }
+    }
+
+    private function updateUserLastLogin() {
+        $db = DB::getInstance()->getConnection();
+        $handle = $db->prepare(
+            'update userdetails set last_login=NOW() where username = :username'
+        );
+        $handle->execute([':username' => $this->user->login]);
     }
 
     private function fixMac($mac) {


### PR DESCRIPTION
When a user logs into the service we record their last login time and then use that as part of the data clearing procedure.  Any account which hasn't logged into GovWifi for 12 months is then purged.