### PR TITLE
Test that auth reject works

### DIFF
--- a/tests/acceptance/RadiusServerTest.php
+++ b/tests/acceptance/RadiusServerTest.php
@@ -28,6 +28,21 @@ class RadiusServerTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @coversNothing Do not count acceptance tests in code coverage analysis.
+     */
+    public function testRadiusPEAPMsChapV2AuthenticationReject() {
+        $template = file_get_contents(self::PEAP_MSCHAP_V2_CONFIG_TEMPLATE);
+        $configuration = str_replace(
+            self::PASSWORD_PLACEHOLDER, 'somewrongpassword',
+            str_replace(
+                self::USERNAME_PLACEHOLDER, TestConstants::getInstance()->getAcceptanceTestUserName(), $template)
+        );
+        file_put_contents(self::CONFIG_FILE, $configuration);
+
+        $this->assertEquals('FAILURE', $this->runEAPOverLanTest());
+    }
+
+    /**
      * @coversNothing
      */
     public function testRadiusHealthCheckAuthentication() {


### PR DESCRIPTION
We are removing logging from the critical path, and need this test to
ensure that we don't authenticate people accidentally by forcing the
rest module in radius to be redundant.