### PR TITLE
Remove old Radius healthcheck

### DIFF
--- a/tests/acceptance/RadiusServerTest.php
+++ b/tests/acceptance/RadiusServerTest.php
@@ -43,15 +43,6 @@ class RadiusServerTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @coversNothing
-     */
-    public function testRadiusHealthCheckUrl() {
-        @file_get_contents(TestConstants::REQUEST_PROTOCOL
-            . TestConstants::getInstance()->getFrontendContainer() . "/");
-        $this->assertEquals(TestConstants::HTTP_OK, $http_response_header[0]);
-    }
-
-    /**
      * @return string
      */
     private function runEAPOverLanTest()


### PR DESCRIPTION
I'm working on removing the old PHP/apache healthcheck and using new Ruby implementation instead. 

Steps:

- remove this test (I'm here now) to make `govwifi-frontend` repo build on Jenkins pass, as Jenkins points to master branch of tests from `govwifi` repo
- push out `govwifi-frontend`
- implement the new test in `govwifi`